### PR TITLE
Steam 862/planned course viz

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A web application for viewing CODEx modeled [Radiation Therapy Treatment Data](h
   - [Interactive Cheat Sheet](https://nerdcave.com/tailwind-cheat-sheet)
 - [Feather Icons](https://feathericons.com/)
   - Specifically using [react-feather](https://github.com/feathericons/react-feather)
+- [FHIRPath](https://hl7.org/fhirpath/)
 
 ## Quick start
 

--- a/src/App.js
+++ b/src/App.js
@@ -73,8 +73,6 @@ function App() {
       const procedures = await fetchProcedures(serverUrl, patient.id);
       const volumes = await fetchVolumes(serverUrl, patient.id);
       const serviceRequests = await fetchServiceRequests(serverUrl, patient.id);
-      console.log(serviceRequests);
-      console.log(mapPlannedCourses(serviceRequests));
       resourceMap.set(patient.id, [
         mapPatient(patient),
         mapPhase(procedures),

--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,42 @@ function App() {
   const [currentPatientQueryIdx, setCurrentPatientQueryIdx] = useState();
   const [patientQueries, setPatientQueries] = useState([
     {
+      id: "Patient-XRTS-01",
+      givenName: "",
+      familyName: "",
+      birthDate: "",
+      gender: "",
+    },
+    {
+      id: "Patient-XRTS-02",
+      givenName: "",
+      familyName: "",
+      birthDate: "",
+      gender: "",
+    },
+    {
+      id: "Patient-XRTS-01-22A",
+      givenName: "",
+      familyName: "",
+      birthDate: "",
+      gender: "",
+    },
+    {
       id: "Patient-XRTS-02-22A",
+      givenName: "",
+      familyName: "",
+      birthDate: "",
+      gender: "",
+    },
+    {
+      id: "Patient-XRTS-03-22A",
+      givenName: "",
+      familyName: "",
+      birthDate: "",
+      gender: "",
+    },
+    {
+      id: "Patient-XRTS-04-22A",
       givenName: "",
       familyName: "",
       birthDate: "",

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import { Plus } from "react-feather";
 import {
   fetchPatients,
   fetchProcedures,
+  fetchServiceRequests,
   fetchVolumes,
   generateQueryUrl,
 } from "./lib/fetchingUtils";
@@ -12,6 +13,7 @@ import {
   mapCourseSummary,
   mapPhase,
   mapVolumes,
+  mapPlannedCourses,
 } from "./lib/mappingUtils";
 import FhirServerUrlInput from "./components/RequestForm/FhirServerUrlInput";
 import PatientQueryList from "./components/RequestForm/PatientQueryList";
@@ -32,14 +34,14 @@ function App() {
   const [currentPatientQueryIdx, setCurrentPatientQueryIdx] = useState();
   const [patientQueries, setPatientQueries] = useState([
     {
-      id: "Patient-XRTS-01",
+      id: "Patient-XRTS-02-22A",
       givenName: "",
       familyName: "",
       birthDate: "",
       gender: "",
     },
     {
-      id: "Patient-XRTS-03",
+      id: "Patient-XRTS-05-22A",
       givenName: "",
       familyName: "",
       birthDate: "",
@@ -70,11 +72,15 @@ function App() {
     for (const patient of patientResources) {
       const procedures = await fetchProcedures(serverUrl, patient.id);
       const volumes = await fetchVolumes(serverUrl, patient.id);
+      const serviceRequests = await fetchServiceRequests(serverUrl, patient.id);
+      console.log(serviceRequests);
+      console.log(mapPlannedCourses(serviceRequests));
       resourceMap.set(patient.id, [
         mapPatient(patient),
         mapPhase(procedures),
         mapCourseSummary(procedures),
         mapVolumes(volumes),
+        mapPlannedCourses(serviceRequests),
       ]);
     }
     setSearchedPatientIds(patientResources.map((patient) => patient.id));

--- a/src/components/DataView/DataView.js
+++ b/src/components/DataView/DataView.js
@@ -2,6 +2,7 @@ import PatientTable from "./PatientTable";
 import TreatmentVolumeTable from "./TreatmentVolumeTable";
 import TreatmentPhaseTable from "./TreatmentPhaseTable";
 import CourseSummaryTable from "./CourseSummaryTable";
+import PlannedCourseTable from "./PlannedCourseTable";
 import PatientSelect from "./PatientSelect";
 import { useState } from "react";
 import _ from "lodash";
@@ -83,8 +84,6 @@ function DataView({ resourceMap = {}, patientIds = [] }) {
     resourceMap
   );
 
-  console.log(plannedCourseData);
-
   const hasPatientData =
     !_.isEmpty(patientData) ||
     !_.isEmpty(treatmentPhaseData) ||
@@ -113,6 +112,7 @@ function DataView({ resourceMap = {}, patientIds = [] }) {
                 title={`Phase ${i + 1}`}
               />
             ))}
+          <PlannedCourseTable className="my-4" data={plannedCourseData} />
           <CourseSummaryTable className="my-4" data={courseSummaryData} />
         </>
       )}

--- a/src/components/DataView/DataView.js
+++ b/src/components/DataView/DataView.js
@@ -8,7 +8,8 @@ import _ from "lodash";
 
 /**
  * Parse and reformat patient data for visualization
- * @param {Object[]} data
+ * @param {Object[]} selectedPatientId Patient to get data for
+ * @param {Object} resourceMap All resources mapped from all available patient data
  * @returns Patient data formatted for the PatientTable visualizer
  */
 function getPatientData(selectedPatientId, resourceMap) {
@@ -18,7 +19,8 @@ function getPatientData(selectedPatientId, resourceMap) {
 
 /**
  * Parse and reformat treatment volume data for visualization
- * @param {Object[]} data
+ * @param {Object[]} selectedPatientId Patient to get data for
+ * @param {Object} resourceMap All resources mapped from all available patient data
  * @returns Treatment volume data formatted for the CourseSummaryTable visualizer
  */
 function getTreatmentVolumesData(selectedPatientId, resourceMap) {
@@ -28,7 +30,8 @@ function getTreatmentVolumesData(selectedPatientId, resourceMap) {
 
 /**
  * Parse and reformat phase data for visualization
- * @param {Object[]} data
+ * @param {Object[]} selectedPatientId Patient to get data for
+ * @param {Object} resourceMap All resources mapped from all available patient data
  * @returns Phase data formatted for the TreatmentPhaseTable visualizer
  */
 function getTreatmentPhaseData(selectedPatientId, resourceMap) {
@@ -37,8 +40,20 @@ function getTreatmentPhaseData(selectedPatientId, resourceMap) {
 }
 
 /**
+ * Parse and reformat planned course for visualization
+ * @param {Object[]} selectedPatientId Patient to get data for
+ * @param {Object} resourceMap All resources mapped from all available patient data
+ * @returns Phase data formatted for the PlannedCourseTable visualizer
+ */
+function getPlannedCourseData(selectedPatientId, resourceMap) {
+  const patientData = resourceMap.get(selectedPatientId);
+  return patientData && patientData[4];
+}
+
+/**
  * Parse and reformat course summary data for visualization
- * @param {Object[]} data
+ * @param {Object[]} selectedPatientId Patient to get data for
+ * @param {Object} resourceMap All resources mapped from all available patient data
  * @returns Course summary data formatted for the CourseSummaryTable visualizer
  */
 function getCourseSummaryData(selectedPatientId, resourceMap) {
@@ -63,10 +78,18 @@ function DataView({ resourceMap = {}, patientIds = [] }) {
     selectedPatientId,
     resourceMap
   );
+  const plannedCourseData = getPlannedCourseData(
+    selectedPatientId,
+    resourceMap
+  );
+
+  console.log(plannedCourseData);
+
   const hasPatientData =
     !_.isEmpty(patientData) ||
     !_.isEmpty(treatmentPhaseData) ||
     !_.isEmpty(treatmentVolumesData) ||
+    !_.isEmpty(plannedCourseData) ||
     !_.isEmpty(courseSummaryData);
   return (
     <>

--- a/src/components/DataView/PlannedCourseTable.js
+++ b/src/components/DataView/PlannedCourseTable.js
@@ -1,0 +1,41 @@
+import SimpleDataTable from "./SimpleDataTable";
+import MultiEntryDataTable from "./MultiEntryDataTable";
+
+function PlannedCourseTable({ data = {}, className }) {
+  if (!data) {
+    return null;
+  }
+  return data.map((plannedCourse, i) => {
+    const numVolumes =
+      plannedCourse["Number of Planned Fractions"] &&
+      plannedCourse["Number of Planned Fractions"].length;
+    const volumesData = [];
+    for (let i = 0; i < numVolumes; i++) {
+      volumesData.push({
+        "Number of Planned Fractions":
+          plannedCourse["Number of Planned Fractions"][i],
+        "Total Planned Dose to Course [cGy]":
+          plannedCourse["Total Planned Dose to Course [cGy]"][i],
+        "Body Sites": plannedCourse["Body Sites"][i],
+      });
+    }
+    const plannedCourseData = { ...plannedCourse };
+    delete plannedCourseData["Number of Planned Fractions"];
+    delete plannedCourseData["Total Planned Dose to Course [cGy]"];
+    delete plannedCourseData["Body Sites"];
+    return (
+      <div className={className}>
+        {/* Display the base course data with a simple table */}
+        <SimpleDataTable data={plannedCourseData} title="Planned Course" />
+        {/* Display the volume data with the multi-entry table */}
+        <MultiEntryDataTable
+          dataArray={volumesData}
+          title="Planned Dose to Volumes"
+          columnTitle="Dose to Volume"
+        />
+      </div>
+    );
+  });
+}
+
+export default PlannedCourseTable;

--- a/src/components/DataView/PlannedCourseTable.js
+++ b/src/components/DataView/PlannedCourseTable.js
@@ -24,9 +24,12 @@ function PlannedCourseTable({ data = {}, className }) {
     delete plannedCourseData["Total Planned Dose to Course [cGy]"];
     delete plannedCourseData["Body Sites"];
     return (
-      <div className={className}>
+      <div key={i} className={className}>
         {/* Display the base course data with a simple table */}
-        <SimpleDataTable data={plannedCourseData} title="Planned Course" />
+        <SimpleDataTable
+          data={plannedCourseData}
+          title={`Planned Course ${i + 1}`}
+        />
         {/* Display the volume data with the multi-entry table */}
         <MultiEntryDataTable
           dataArray={volumesData}

--- a/src/components/RequestForm/PatientQueryList.js
+++ b/src/components/RequestForm/PatientQueryList.js
@@ -48,7 +48,7 @@ function PatientQueryList({
   }
 
   return (
-    <ul className="max-h-72 overflow-y-auto">
+    <ul className="max-h-96 overflow-y-auto">
       {patientQueries.map((patientQuery, i) => {
         return (
           <li

--- a/src/lib/fetchingUtils.js
+++ b/src/lib/fetchingUtils.js
@@ -73,7 +73,7 @@ function generateQueryUrl(serverUrl, queryObj) {
  * @returns {Object[]} Returns an array of FHIR Procedure resources for that Patient
  */
 async function fetchProcedures(serverUrl, patientId) {
-  let procedureResources = await axios
+  const procedureResources = await axios
     .get(`${serverUrl}/Procedure?subject:Patient=${patientId}`)
     .then((res) => res.data)
     .catch((e) => {
@@ -89,9 +89,7 @@ async function fetchProcedures(serverUrl, patientId) {
  * @returns {Object[]} Returns an array of FHIR BodyStructure resources for that Patient
  */
 async function fetchVolumes(serverUrl, patientId) {
-  // TODO: Determine why this is a body structure and
-  //       if we need to filter out non-volume BodyStructure resources
-  let volumeResources = await axios
+  const volumeResources = await axios
     .get(`${serverUrl}/BodyStructure?patient:Patient=${patientId}`)
     .then((res) => res.data)
     .catch((e) => {
@@ -101,4 +99,26 @@ async function fetchVolumes(serverUrl, patientId) {
   return volumeResources;
 }
 
-export { fetchPatients, fetchProcedures, fetchVolumes, generateQueryUrl };
+/**
+ * Takes a patient ID and fetches ServiceRequest resources that patient
+ * @param {String} patientId - A patient ID to fetch ServiceRequest resources for
+ * @returns {Object[]} Returns an array of FHIR ServiceRequest resources for that Patient
+ */
+async function fetchServiceRequests(serverUrl, patientId) {
+  const serviceRequests = await axios
+    .get(`${serverUrl}/ServiceRequest?subject:Patient=${patientId}`)
+    .then((res) => res.data)
+    .catch((e) => {
+      console.error(e);
+    });
+
+  return serviceRequests;
+}
+
+export {
+  fetchPatients,
+  fetchProcedures,
+  fetchVolumes,
+  fetchServiceRequests,
+  generateQueryUrl,
+};

--- a/src/lib/mappingUtils.js
+++ b/src/lib/mappingUtils.js
@@ -151,20 +151,17 @@ function mapPlannedCourses(serviceRequests) {
       plannedCourse,
       "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-sessions').valueUnsignedInt.single()"
     )[0];
-    // Should only ever be one value for # fractions
     output["Number of Planned Fractions"] = fhirpath.evaluate(
       plannedCourse,
       "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-dose-planned-to-volume').extension.where(url = 'fractions').valuePositiveInt"
-    )[0];
-    // Should only ever be one value for planned dosage
+    );
     output["Total Planned Dose to Course [cGy]"] = fhirpath.evaluate(
       plannedCourse,
       "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-dose-planned-to-volume').extension.where(url = 'totalDose').valueQuantity.value"
-    )[0];
+    );
     output["Body Sites"] = fhirpath
       .evaluate(plannedCourse, "ServiceRequest.bodySite.coding")
-      .map((coding) => coding.display)
-      .join("; ");
+      .map((coding) => coding.display);
     //NOT included yet
     // output["Energy or Isotope"]
     // output["Treatment Device"]

--- a/src/lib/mappingUtils.js
+++ b/src/lib/mappingUtils.js
@@ -22,7 +22,6 @@ function mapPatient(patient) {
  * @returns {Object} Returns an object with key/value pairs of data to display in the table
  */
 function mapCourseSummary(procedure) {
-  console.log(procedure);
   const summary = fhirpath.evaluate(
     procedure,
     "Bundle.entry.where(resource.meta.profile contains 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-course-summary').resource"

--- a/src/lib/mappingUtils.js
+++ b/src/lib/mappingUtils.js
@@ -120,33 +120,29 @@ function mapPlannedCourses(serviceRequests) {
   );
   const outputs = [];
   plannedCourses.forEach((plannedCourse) => {
+    console.log(plannedCourse);
     const output = {};
     output["Course Label"] = plannedCourse.identifier
       ? plannedCourse.identifier[0].value
       : "N/A";
     output["Course Status"] = plannedCourse.status;
     output["Request Intent"] = plannedCourse.intent;
-    output["Procedure Intent"] = fhirpath
-      .evaluate(
-        plannedCourse,
-        "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-procedure-intent').valueCodeableConcept.single().coding"
-      )
-      .map((intent) => intent.display)[0];
-
-    output["Modalities"] = fhirpath
-      .evaluate(
-        plannedCourse,
-        "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality').valueCodeableConcept.coding"
-      )
-      .map((modality) => modality.display)[0];
-    output["Techniques"] = fhirpath
-      .evaluate(
-        plannedCourse,
-        "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-technique').valueCodeableConcept.coding"
-      )
-      .map((technique) => technique.display)
-      .join("; ");
-    // Should only ever be one value for # sessions
+    // IG states there will be at most one procedure intent
+    output["Procedure Intent"] = fhirpath.evaluate(
+      plannedCourse,
+      "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-procedure-intent').valueCodeableConcept.single().coding.display"
+    )[0];
+    // One display value should suffice
+    output["Modalities"] = fhirpath.evaluate(
+      plannedCourse,
+      "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality').valueCodeableConcept.coding.display"
+    )[0];
+    // One display value should suffice
+    output["Techniques"] = fhirpath.evaluate(
+      plannedCourse,
+      "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-technique').valueCodeableConcept.coding.display"
+    )[0];
+    // IG states there will be at most one value for # sessions
     output["Number of Sessions"] = fhirpath.evaluate(
       plannedCourse,
       "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-sessions').valueUnsignedInt.single()"
@@ -159,9 +155,10 @@ function mapPlannedCourses(serviceRequests) {
       plannedCourse,
       "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-dose-planned-to-volume').extension.where(url = 'totalDose').valueQuantity.value"
     );
-    output["Body Sites"] = fhirpath
-      .evaluate(plannedCourse, "ServiceRequest.bodySite.coding")
-      .map((coding) => coding.display);
+    output["Body Sites"] = fhirpath.evaluate(
+      plannedCourse,
+      "ServiceRequest.bodySite.coding.display"
+    );
     //NOT included yet
     // output["Energy or Isotope"]
     // output["Treatment Device"]

--- a/src/lib/mappingUtils.js
+++ b/src/lib/mappingUtils.js
@@ -60,9 +60,10 @@ function mapCourseSummary(procedure) {
     summary,
     "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-dose-delivered-to-volume').extension.where(url = 'totalDoseDelivered').valueQuantity.value"
   );
-  output["Body Sites"] = fhirpath
-    .evaluate(summary, "Procedure.bodySite.coding")
-    .map((coding) => coding.display);
+  output["Body Sites"] = fhirpath.evaluate(
+    summary,
+    "Procedure.bodySite.coding.display"
+  );
   return output;
 }
 
@@ -120,7 +121,6 @@ function mapPlannedCourses(serviceRequests) {
   );
   const outputs = [];
   plannedCourses.forEach((plannedCourse) => {
-    console.log(plannedCourse);
     const output = {};
     output["Course Label"] = plannedCourse.identifier
       ? plannedCourse.identifier[0].value

--- a/src/lib/mappingUtils.js
+++ b/src/lib/mappingUtils.js
@@ -6,7 +6,7 @@ const fhirpath = require("fhirpath");
  * @returns {Object} Returns an object with key/value pairs of data to display in the table
  */
 function mapPatient(patient) {
-  let output = {};
+  const output = {};
   output["ID"] = patient.identifier[0].value;
   output["First Name"] = patient.name[0].given.join(" ");
   output["Last Name"] = patient.name[0].family;
@@ -22,28 +22,29 @@ function mapPatient(patient) {
  * @returns {Object} Returns an object with key/value pairs of data to display in the table
  */
 function mapCourseSummary(procedure) {
-  let summary = fhirpath.evaluate(
+  console.log(procedure);
+  const summary = fhirpath.evaluate(
     procedure,
-    "Bundle.entry.where(resource.meta.profile.where($this = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-course-summary')).resource"
+    "Bundle.entry.where(resource.meta.profile contains 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-course-summary').resource"
   )[0];
-  let output = {};
+  const output = {};
   output["Course Label"] = summary.identifier
     ? summary.identifier[0].value
     : "N/A";
   output["Treatment Status"] = summary.status;
-  let intent = fhirpath.evaluate(
+  const intent = fhirpath.evaluate(
     summary,
     "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-procedure-intent').valueCodeableConcept.coding"
   )[0];
   output["Treatment Intent"] = intent ? intent.display : undefined;
   output["Start Date"] = summary.performedPeriod.start;
   output["End Date"] = summary.performedPeriod.end;
-  let modality = fhirpath.evaluate(
+  const modality = fhirpath.evaluate(
     summary,
     "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality').valueCodeableConcept.coding"
   )[0];
   output["Modalities"] = modality ? modality.display : undefined;
-  let technique = fhirpath.evaluate(
+  const technique = fhirpath.evaluate(
     summary,
     "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-technique').valueCodeableConcept.coding"
   )[0];
@@ -72,24 +73,24 @@ function mapCourseSummary(procedure) {
  * @returns {Object[]} Returns an array of objects with key/value pairs of data to display in the table
  */
 function mapPhase(procedure) {
-  let phases = fhirpath.evaluate(
+  const phases = fhirpath.evaluate(
     procedure,
     "Bundle.entry.where(resource.code.coding.code = 'USCRS-33527').resource"
   );
-  let outputs = [];
+  const outputs = [];
   phases.forEach((phase) => {
-    let output = {};
+    const output = {};
     output["Phase Label"] = phase.identifier
       ? phase.identifier[0].value
       : "N/A";
     output["Start Date"] = phase.performedPeriod.start;
     output["End Date"] = phase.performedPeriod.end;
-    let modality = fhirpath.evaluate(
+    const modality = fhirpath.evaluate(
       phase,
       "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality').valueCodeableConcept.coding"
     )[0];
     output["Modalities"] = modality ? modality.display : undefined;
-    let technique = fhirpath.evaluate(
+    const technique = fhirpath.evaluate(
       phase,
       "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-technique').valueCodeableConcept.coding"
     )[0];
@@ -114,13 +115,13 @@ function mapPhase(procedure) {
  * @returns {Object[]} Returns an array of objects with key/value pairs of data to display in the table
  */
 function mapPlannedCourses(serviceRequests) {
-  let plannedCourses = fhirpath.evaluate(
+  const plannedCourses = fhirpath.evaluate(
     serviceRequests,
     "Bundle.entry.where(resource.code.coding.code = 'USCRS-33529').resource"
   );
-  let outputs = [];
+  const outputs = [];
   plannedCourses.forEach((plannedCourse) => {
-    let output = {};
+    const output = {};
     output["Course Label"] = plannedCourse.identifier
       ? plannedCourse.identifier[0].value
       : "N/A";
@@ -177,10 +178,10 @@ function mapPlannedCourses(serviceRequests) {
  * @returns {Object[]} Returns an array of objects with key/value pairs of data to display in the table
  */
 function mapVolumes(volumes) {
-  let bodyStructures = fhirpath.evaluate(volumes, "Bundle.entry.resource");
-  let outputs = [];
+  const bodyStructures = fhirpath.evaluate(volumes, "Bundle.entry.resource");
+  const outputs = [];
   bodyStructures.forEach((volume) => {
-    let output = {};
+    const output = {};
     output["Volume Label"] = fhirpath.evaluate(
       volume,
       "BodyStructure.identifier.where(use = 'usual').value"

--- a/src/lib/mappingUtils.js
+++ b/src/lib/mappingUtils.js
@@ -24,7 +24,7 @@ function mapPatient(patient) {
 function mapCourseSummary(procedure) {
   let summary = fhirpath.evaluate(
     procedure,
-    "Bundle.entry.where(resource.meta.profile.first() = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-course-summary').resource"
+    "Bundle.entry.where(resource.meta.profile.where($this = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-course-summary')).resource"
   )[0];
   let output = {};
   output["Course Label"] = summary.identifier
@@ -108,6 +108,48 @@ function mapPhase(procedure) {
 }
 
 /**
+ * Takes a bundle of serviceRequests returned and returns an array of mappings of PlannedCourse data to be displayed in the table
+ * Based on https://build.fhir.org/ig/HL7/codex-radiation-therapy/StructureDefinition-codexrt-radiotherapy-planned-course.html
+ * @param {Object} procedure - A bundle of serviceRequests
+ * @returns {Object[]} Returns an array of objects with key/value pairs of data to display in the table
+ */
+function mapPlannedCourses(serviceRequests) {
+  let plannedCourses = fhirpath.evaluate(
+    serviceRequests,
+    "Bundle.entry.where(resource.meta.profile.where($this = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-planned-course')).resource"
+  );
+  let outputs = [];
+  plannedCourses.forEach((plannedCourse) => {
+    let output = {};
+    output["Course Label"] = plannedCourse.identifier
+      ? plannedCourse.identifier[0].value
+      : "N/A";
+    // output["Start Date"] = phase.performedPeriod.start;
+    // output["End Date"] = phase.performedPeriod.end;
+    // let modality = fhirpath.evaluate(
+    //   phase,
+    //   "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality').valueCodeableConcept.coding"
+    // )[0];
+    // output["Modalities"] = modality ? modality.display : undefined;
+    // let technique = fhirpath.evaluate(
+    //   phase,
+    //   "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-technique').valueCodeableConcept.coding"
+    // )[0];
+    // output["Techniques"] = technique ? technique.display : undefined;
+    // output["Number of Fractions Delivered"] = fhirpath.evaluate(
+    //   phase,
+    //   "Procedure.extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-fractions-delivered').valueUnsignedInt"
+    // )[0];
+    // output["Total Dose Delivered from Phase [cGy]"] = fhirpath.evaluate(
+    //   phase,
+    //   "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-dose-delivered-to-volume').extension.where(url = 'totalDoseDelivered').valueQuantity.value"
+    // );
+    outputs.push(output);
+  });
+  return outputs;
+}
+
+/**
  * Takes a bundle of body structures returned by makeRequests and returns an array of mappings of Volume data to be displayed in the table
  * @param {Object} volumes - A bundle of radiotherapy volume body structures
  * @returns {Object[]} Returns an array of objects with key/value pairs of data to display in the table
@@ -135,4 +177,10 @@ function mapVolumes(volumes) {
   return outputs;
 }
 
-export { mapPatient, mapCourseSummary, mapPhase, mapVolumes };
+export {
+  mapPatient,
+  mapCourseSummary,
+  mapPhase,
+  mapVolumes,
+  mapPlannedCourses,
+};


### PR DESCRIPTION
Creates a mapper and a visualizer for Planned Course data based on [this profile](https://build.fhir.org/ig/HL7/codex-radiation-therapy/StructureDefinition-codexrt-radiotherapy-planned-course.html). As for the data elements visualized, I mirror the Course Summary visualization. 

A few other small changes included in this PR: 
- Added a link to the FHIRpath docs;
- Added new patients to the default list of queries; these will have more complete records;
- `src/components/DataView/DataView.js`: Made the comments more accurate
- Increases the max-height of the patient query list;
- `src/lib/fetchingUtils.js`: Turned some lets into consts