### PR TITLE
STEAM-872/support multiple course summaries in mapping and visualization

### DIFF
--- a/src/components/DataView/ProfileVisualizers/CourseSummaryTable.js
+++ b/src/components/DataView/ProfileVisualizers/CourseSummaryTable.js
@@ -1,34 +1,39 @@
 import SimpleDataTable from "../SimpleDataTable";
 import MultiEntryDataTable from "../MultiEntryDataTable";
 
-function CourseSummaryTable({ data = {}, className }) {
-  const numVolumes =
-    data["Number of Delivered Fractions"] &&
-    data["Number of Delivered Fractions"].length;
-  const volumesData = [];
-  for (let i = 0; i < numVolumes; i++) {
-    volumesData.push({
-      "Number of Delivered Fractions": data["Number of Delivered Fractions"][i],
-      "Total Delivered Dose [cGy]": data["Total Delivered Dose [cGy]"][i],
-      "Body Sites": data["Body Sites"][i],
-    });
-  }
-  const courseData = { ...data };
-  delete courseData["Number of Delivered Fractions"];
-  delete courseData["Total Delivered Dose [cGy]"];
-  delete courseData["Body Sites"];
-  return (
-    <div className={className}>
-      {/* Display the base course data with a simple table */}
-      <SimpleDataTable data={courseData} title="Course Summary" />
-      {/* Display the volume data with the multi-entry table */}
-      <MultiEntryDataTable
-        dataArray={volumesData}
-        title="Dose Delivered to Volumes"
-        columnTitle="Dose to Volume"
-      />
-    </div>
-  );
+function CourseSummaryTable({ data = [], className }) {
+  return data.map((courseSummary, i) => {
+    const title = `Course Summary ${i + 1}`;
+    const numVolumes =
+      courseSummary["Number of Delivered Fractions"] &&
+      courseSummary["Number of Delivered Fractions"].length;
+    const volumesData = [];
+    for (let i = 0; i < numVolumes; i++) {
+      volumesData.push({
+        "Number of Delivered Fractions":
+          courseSummary["Number of Delivered Fractions"][i],
+        "Total Delivered Dose [cGy]":
+          courseSummary["Total Delivered Dose [cGy]"][i],
+        "Body Sites": courseSummary["Body Sites"][i],
+      });
+    }
+    const courseData = { ...courseSummary };
+    delete courseData["Number of Delivered Fractions"];
+    delete courseData["Total Delivered Dose [cGy]"];
+    delete courseData["Body Sites"];
+    return (
+      <div key={i} className={className}>
+        {/* Display the base course data with a simple table */}
+        <SimpleDataTable data={courseData} title={title} />
+        {/* Display the volume data with the multi-entry table */}
+        <MultiEntryDataTable
+          dataArray={volumesData}
+          title="Dose Delivered to Volumes"
+          columnTitle="Dose to Volume"
+        />
+      </div>
+    );
+  });
 }
 
 export default CourseSummaryTable;

--- a/src/components/DataView/ProfileVisualizers/PlannedCourseTable.js
+++ b/src/components/DataView/ProfileVisualizers/PlannedCourseTable.js
@@ -1,11 +1,9 @@
 import SimpleDataTable from "../SimpleDataTable";
 import MultiEntryDataTable from "../MultiEntryDataTable";
 
-function PlannedCourseTable({ data = {}, className }) {
-  if (!data) {
-    return null;
-  }
+function PlannedCourseTable({ data = [], className }) {
   return data.map((plannedCourse, i) => {
+    const title = `Planned Course ${i + 1}`;
     const numVolumes =
       plannedCourse["Number of Planned Fractions"] &&
       plannedCourse["Number of Planned Fractions"].length;
@@ -26,10 +24,7 @@ function PlannedCourseTable({ data = {}, className }) {
     return (
       <div key={i} className={className}>
         {/* Display the base course data with a simple table */}
-        <SimpleDataTable
-          data={plannedCourseData}
-          title={`Planned Course ${i + 1}`}
-        />
+        <SimpleDataTable data={plannedCourseData} title={title} />
         {/* Display the volume data with the multi-entry table */}
         <MultiEntryDataTable
           dataArray={volumesData}

--- a/src/components/DataView/ProfileVisualizers/PlannedTreatmentPhaseTable.js
+++ b/src/components/DataView/ProfileVisualizers/PlannedTreatmentPhaseTable.js
@@ -2,10 +2,7 @@ import _ from "lodash";
 import SimpleDataTable from "../SimpleDataTable";
 import MultiEntryDataTable from "../MultiEntryDataTable";
 
-function PlannedTreatmentPhaseTable({ data = {}, className }) {
-  if (!data) {
-    return null;
-  }
+function PlannedTreatmentPhaseTable({ data = [], className }) {
   return data.map((plannedPhase, i) => {
     const title = `Planned Phase ${i + 1}`;
     // Compact so we don't make space for empty entries

--- a/src/components/DataView/ProfileVisualizers/TreatmentPhaseTable.js
+++ b/src/components/DataView/ProfileVisualizers/TreatmentPhaseTable.js
@@ -2,10 +2,7 @@ import _ from "lodash";
 import SimpleDataTable from "../SimpleDataTable";
 import MultiEntryDataTable from "../MultiEntryDataTable";
 
-function TreatmentPhaseTable({ data = {}, className }) {
-  if (!data) {
-    return null;
-  }
+function TreatmentPhaseTable({ data = [], className }) {
   return data.map((treatmentPhase, i) => {
     const title = `Phase ${i + 1}`;
     // Compact so we don't make space for empty entries

--- a/src/lib/mappingUtils.js
+++ b/src/lib/mappingUtils.js
@@ -22,46 +22,53 @@ function mapPatient(patient) {
  * @returns {Object} Returns an object with key/value pairs of data to display in the table
  */
 function mapCourseSummary(procedure) {
-  const summary = fhirpath.evaluate(
+  const summaries = fhirpath.evaluate(
     procedure,
     "Bundle.entry.where(resource.meta.profile contains 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-course-summary').resource"
-  )[0];
-  const output = {};
-  output["Course Label"] = summary.identifier
-    ? summary.identifier[0].value
-    : "N/A";
-  output["Treatment Status"] = summary.status;
-  output["Treatment Intent"] = fhirpath.evaluate(
-    summary,
-    "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-procedure-intent').valueCodeableConcept.coding.display"
-  )[0];
-  output["Start Date"] = summary.performedPeriod.start;
-  output["End Date"] = summary.performedPeriod.end;
-  output["Modalities"] = fhirpath.evaluate(
-    summary,
-    "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality').valueCodeableConcept.coding.display"
-  )[0];
-  output["Techniques"] = fhirpath.evaluate(
-    summary,
-    "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-technique').valueCodeableConcept.coding.display"
-  )[0];
-  output["Number of Sessions"] = fhirpath.evaluate(
-    summary,
-    "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-sessions').valueUnsignedInt"
-  )[0];
-  output["Number of Delivered Fractions"] = fhirpath.evaluate(
-    summary,
-    "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-dose-delivered-to-volume').extension.where(url = 'fractionsDelivered').valueUnsignedInt"
   );
-  output["Total Delivered Dose [cGy]"] = fhirpath.evaluate(
-    summary,
-    "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-dose-delivered-to-volume').extension.where(url = 'totalDoseDelivered').valueQuantity.value"
-  );
-  output["Body Sites"] = fhirpath.evaluate(
-    summary,
-    "Procedure.bodySite.coding.display"
-  );
-  return output;
+  const outputs = [];
+  summaries.forEach((summary) => {
+    const output = {};
+    output["Course Label"] = summary.identifier
+      ? summary.identifier[0].value
+      : "N/A";
+    output["Treatment Status"] = summary.status;
+    const intent = fhirpath.evaluate(
+      summary,
+      "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-procedure-intent').valueCodeableConcept.coding"
+    )[0];
+    output["Treatment Intent"] = intent ? intent.display : undefined;
+    output["Start Date"] = summary.performedPeriod.start;
+    output["End Date"] = summary.performedPeriod.end;
+    const modality = fhirpath.evaluate(
+      summary,
+      "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality').valueCodeableConcept.coding"
+    )[0];
+    output["Modalities"] = modality ? modality.display : undefined;
+    const technique = fhirpath.evaluate(
+      summary,
+      "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-technique').valueCodeableConcept.coding"
+    )[0];
+    output["Techniques"] = technique ? technique.display : undefined;
+    output["Number of Sessions"] = fhirpath.evaluate(
+      summary,
+      "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-sessions').valueUnsignedInt"
+    )[0];
+    output["Number of Delivered Fractions"] = fhirpath.evaluate(
+      summary,
+      "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-dose-delivered-to-volume').extension.where(url = 'fractionsDelivered').valueUnsignedInt"
+    );
+    output["Total Delivered Dose [cGy]"] = fhirpath.evaluate(
+      summary,
+      "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-dose-delivered-to-volume').extension.where(url = 'totalDoseDelivered').valueQuantity.value"
+    );
+    output["Body Sites"] = fhirpath.evaluate(
+      summary,
+      "Procedure.bodySite.coding.display"
+    );
+    outputs.push(output);
+  });
+  return outputs;
 }
 
 /**

--- a/src/lib/mappingUtils.js
+++ b/src/lib/mappingUtils.js
@@ -33,23 +33,20 @@ function mapCourseSummary(procedure) {
       ? summary.identifier[0].value
       : "N/A";
     output["Treatment Status"] = summary.status;
-    const intent = fhirpath.evaluate(
+    output["Treatment Intent"] = fhirpath.evaluate(
       summary,
-      "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-procedure-intent').valueCodeableConcept.coding"
+      "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-procedure-intent').valueCodeableConcept.coding.display"
     )[0];
-    output["Treatment Intent"] = intent ? intent.display : undefined;
     output["Start Date"] = summary.performedPeriod.start;
     output["End Date"] = summary.performedPeriod.end;
-    const modality = fhirpath.evaluate(
+    output["Modalities"] = fhirpath.evaluate(
       summary,
-      "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality').valueCodeableConcept.coding"
+      "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality').valueCodeableConcept.coding.display"
     )[0];
-    output["Modalities"] = modality ? modality.display : undefined;
-    const technique = fhirpath.evaluate(
+    output["Techniques"] = fhirpath.evaluate(
       summary,
-      "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-technique').valueCodeableConcept.coding"
+      "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-technique').valueCodeableConcept.coding.display"
     )[0];
-    output["Techniques"] = technique ? technique.display : undefined;
     output["Number of Sessions"] = fhirpath.evaluate(
       summary,
       "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-sessions').valueUnsignedInt"


### PR DESCRIPTION
Mirroring`PlannedCourseTable`, the `CourseSummaryTable` now assumes an array of course summary data objects as props, iterating over them and rendering one table for each. Accordingly, `mapCourseSummary` now produces an array of course summary data objects as output. 

Additionally, this PR introduces a few small improvements in other files: 
- `PlannedCourseTable.js`, `PlannedTreatmentPhaseTable.js` & `TreatmentPhaseTable.js`: Addresses some unreachable code (note: `{}` in JS is Truthy) and fixes default variable values to type-appropriate alternatives.
 