### PR TITLE
STEAM-874: dataDisplay function incorrectly displays 4-digit numbers as dates. 

### DIFF
--- a/src/lib/dataDisplay.js
+++ b/src/lib/dataDisplay.js
@@ -10,19 +10,26 @@ function dateFormat(data) {
   });
 }
 
+function booleanFormat(data) {
+  return data ? "True" : "False";
+}
+
 function isDate(data) {
-  return DateTime.fromISO(data).isValid;
+  // Dates and Datetimes are JSON strings according to FHIR Datatype spec
+  // https://www.hl7.org/fhir/datatypes.html#date
+  return typeof data === "string" && DateTime.fromISO(data).isValid;
 }
 
 function isEmpty(data) {
   return _.isUndefined(data) || _.isNull(data);
 }
 
-function dataDisplay(data) {
+function dataDisplay(data, type) {
   if (isEmpty(data)) {
+    // Always check for empty data
     return <EmptyComponent />;
   } else if (isBoolean(data)) {
-    return data ? "True" : "False";
+    return booleanFormat(data);
   } else if (isDate(data)) {
     return dateFormat(data);
   } else {

--- a/src/lib/dataDisplay.js
+++ b/src/lib/dataDisplay.js
@@ -24,7 +24,7 @@ function isEmpty(data) {
   return _.isUndefined(data) || _.isNull(data);
 }
 
-function dataDisplay(data, type) {
+function dataDisplay(data) {
   if (isEmpty(data)) {
     // Always check for empty data
     return <EmptyComponent />;


### PR DESCRIPTION
Addresses bug where four-digit numbers get formatted as dates, due to YYYY being a valid ISO date format. This PR fixes this by only displaying strings as dates; this ensures that valid 'YYYY' dates will be formatted as dates if received, and that four digit numbers won't. 