### PR TITLE
Support k-many modalities and techniques

### DIFF
--- a/src/components/DataView/ProfileVisualizers/TreatmentPhaseTable.js
+++ b/src/components/DataView/ProfileVisualizers/TreatmentPhaseTable.js
@@ -20,7 +20,7 @@ function TreatmentPhaseTable({ data = [], className }) {
     const treatmentPhaseData = { ...treatmentPhase };
     delete treatmentPhaseData["Total Dose Delivered [cGy]"];
     return (
-      <div className={className}>
+      <div className={className} key={i}>
         {/* Display the base phase data with a simple table */}
         <SimpleDataTable data={treatmentPhaseData} title={title} />
         {/* Display the volume data with the multi-entry table */}

--- a/src/components/DataView/TableData.js
+++ b/src/components/DataView/TableData.js
@@ -5,7 +5,7 @@ function TableData({ isFirstCol, data }) {
     return (
       <th
         scope="row"
-        className={`font-medium px-6 py-3 text-sm text-gray-900 overflow-x-auto `}
+        className={`font-medium px-6 py-3 text-sm text-gray-900 overflow-x-auto whitespace-pre-wrap`}
         style={{
           wordBreak: "break-word",
           minWidth: "10rem",
@@ -17,7 +17,7 @@ function TableData({ isFirstCol, data }) {
   } else {
     return (
       <td
-        className={`font-light px-6 py-3 text-sm text-gray-900 overflow-x-auto `}
+        className={`font-light px-6 py-3 text-sm text-gray-900 overflow-x-auto whitespace-pre-wrap`}
         style={{
           wordBreak: "break-word",
           minWidth: "20rem",

--- a/src/lib/mappingUtils.js
+++ b/src/lib/mappingUtils.js
@@ -1,10 +1,10 @@
 const fhirpath = require("fhirpath");
 
 // Some common getters with complex FHIRpaths
-function getProcedureIntent(resource, resourceType) {
+function getProcedureIntent(resource) {
   return fhirpath.evaluate(
     resource,
-    `${resourceType}.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-procedure-intent').valueCodeableConcept.single().coding.display`
+    `Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-procedure-intent').valueCodeableConcept.single().coding.display`
   )[0];
 }
 function getModalities(resource, resourceType) {

--- a/src/lib/mappingUtils.js
+++ b/src/lib/mappingUtils.js
@@ -13,7 +13,7 @@ function getModalities(resource, resourceType) {
       resource,
       `${resourceType}.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality').valueCodeableConcept.coding.display`
     )
-    .join(", ");
+    .join("\n");
 }
 function getTechniques(resource, resourceType) {
   return fhirpath
@@ -21,7 +21,7 @@ function getTechniques(resource, resourceType) {
       resource,
       `${resourceType}.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-technique').valueCodeableConcept.coding.display`
     )
-    .join(", ");
+    .join("\n");
 }
 function getBodySites(resource, resourceType) {
   return fhirpath.evaluate(resource, `${resourceType}.bodySite.coding.display`);

--- a/src/lib/mappingUtils.js
+++ b/src/lib/mappingUtils.js
@@ -1,10 +1,10 @@
 const fhirpath = require("fhirpath");
 
 // Some common getters with complex FHIRpaths
-function getProcedureIntent(resource) {
+function getProcedureIntent(resource, resourceType) {
   return fhirpath.evaluate(
     resource,
-    `Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-procedure-intent').valueCodeableConcept.single().coding.display`
+    `${resourceType}.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-procedure-intent').valueCodeableConcept.single().coding.display`
   )[0];
 }
 function getModalities(resource, resourceType) {
@@ -60,7 +60,7 @@ function mapCourseSummary(procedure) {
       ? summary.identifier[0].value
       : "N/A";
     output["Treatment Status"] = summary.status;
-    output["Treatment Intent"] = getProcedureIntent(summary);
+    output["Treatment Intent"] = getProcedureIntent(summary, "Procedure");
     output["Start Date"] = summary.performedPeriod.start;
     output["End Date"] = summary.performedPeriod.end;
     output["Modalities"] = getModalities(summary, "Procedure");
@@ -177,7 +177,10 @@ function mapPlannedCourses(serviceRequests) {
     output["Course Status"] = plannedCourse.status;
     output["Request Intent"] = plannedCourse.intent;
     // IG states there will be at most one procedure intent
-    output["Procedure Intent"] = getProcedureIntent(plannedCourse);
+    output["Procedure Intent"] = getProcedureIntent(
+      plannedCourse,
+      "ServiceRequest"
+    );
     // One display value should suffice
     output["Modalities"] = getModalities(plannedCourse, "ServiceRequest");
     // One display value should suffice


### PR DESCRIPTION
One more small piece of feedback from Michelle and Anthony - there can be 0...* many modality-and-technique extension instances on RTTD resources. This MR takes the list of k-many instances and joins them in a comma-space-separated list of display strings. It also creates a few generic functions for getting Techniques, Modalities, Procedure Intents, and Body Sites.

![image](https://user-images.githubusercontent.com/5703736/166513903-7d07f12b-d599-4b31-905d-c3e71c403433.png)
