### PR TITLE
Show headers for empty tables alerting user where there is no data

### DIFF
--- a/src/components/DataView/DataView.js
+++ b/src/components/DataView/DataView.js
@@ -5,7 +5,6 @@ import TreatmentPhaseTable from "./ProfileVisualizers/TreatmentPhaseTable";
 import CourseSummaryTable from "./ProfileVisualizers/CourseSummaryTable";
 import PlannedCourseTable from "./ProfileVisualizers/PlannedCourseTable";
 import PatientSelect from "./PatientSelect";
-import SimpleDataTable from "./SimpleDataTable";
 import { useState } from "react";
 import _ from "lodash";
 
@@ -118,66 +117,15 @@ function DataView({ resourceMap = {}, patientIds = [] }) {
       {!hasPatientData && <p>No Patient Data found for {selectedPatientId}</p>}
       {hasPatientData && (
         <>
-          {!_.isEmpty(patientData) ? (
-            <PatientTable className="my-4" data={patientData} />
-          ) : (
-            <SimpleDataTable
-              className="my-4"
-              data={{ "No data found": "" }}
-              title={"Patient Information"}
-            />
-          )}
-          {!_.isEmpty(treatmentVolumesData) ? (
-            <TreatmentVolumeTable
-              className="my-4"
-              data={treatmentVolumesData}
-            />
-          ) : (
-            <SimpleDataTable
-              className="my-4"
-              data={{ "No data found": "" }}
-              title={"Radiotherapy Volumes (Targets)"}
-            />
-          )}
-          {!_.isEmpty(treatmentPhaseData) ? (
-            <TreatmentPhaseTable className="my-4" data={treatmentPhaseData} />
-          ) : (
-            <SimpleDataTable
-              className="my-4"
-              data={{ "No data found": "" }}
-              title={"Phase"}
-            />
-          )}
-          {!_.isEmpty(plannedTreatmentPhaseData) ? (
-            <PlannedTreatmentPhaseTable
-              className="my-4"
-              data={plannedTreatmentPhaseData}
-            />
-          ) : (
-            <SimpleDataTable
-              className="my-4"
-              data={{ "No data found": "" }}
-              title={"Planned Phase"}
-            />
-          )}
-          {!_.isEmpty(plannedCourseData) ? (
-            <PlannedCourseTable className="my-4" data={plannedCourseData} />
-          ) : (
-            <SimpleDataTable
-              className="my-4"
-              data={{ "No data found": "" }}
-              title={"Planned Course"}
-            />
-          )}
-          {!_.isEmpty(courseSummaryData) ? (
-            <CourseSummaryTable className="my-4" data={courseSummaryData} />
-          ) : (
-            <SimpleDataTable
-              className="my-4"
-              data={{ "No data found": "" }}
-              title={"Course Summary"}
-            />
-          )}
+          <PatientTable className="my-4" data={patientData} />
+          <TreatmentVolumeTable className="my-4" data={treatmentVolumesData} />
+          <TreatmentPhaseTable className="my-4" data={treatmentPhaseData} />
+          <PlannedTreatmentPhaseTable
+            className="my-4"
+            data={plannedTreatmentPhaseData}
+          />
+          <PlannedCourseTable className="my-4" data={plannedCourseData} />
+          <CourseSummaryTable className="my-4" data={courseSummaryData} />
         </>
       )}
     </>

--- a/src/components/DataView/DataView.js
+++ b/src/components/DataView/DataView.js
@@ -5,6 +5,7 @@ import TreatmentPhaseTable from "./ProfileVisualizers/TreatmentPhaseTable";
 import CourseSummaryTable from "./ProfileVisualizers/CourseSummaryTable";
 import PlannedCourseTable from "./ProfileVisualizers/PlannedCourseTable";
 import PatientSelect from "./PatientSelect";
+import SimpleDataTable from "./SimpleDataTable";
 import { useState } from "react";
 import _ from "lodash";
 
@@ -117,15 +118,66 @@ function DataView({ resourceMap = {}, patientIds = [] }) {
       {!hasPatientData && <p>No Patient Data found for {selectedPatientId}</p>}
       {hasPatientData && (
         <>
-          <PatientTable className="my-4" data={patientData} />
-          <TreatmentVolumeTable className="my-4" data={treatmentVolumesData} />
-          <TreatmentPhaseTable className="my-4" data={treatmentPhaseData} />
-          <PlannedTreatmentPhaseTable
-            className="my-4"
-            data={plannedTreatmentPhaseData}
-          />
-          <PlannedCourseTable className="my-4" data={plannedCourseData} />
-          <CourseSummaryTable className="my-4" data={courseSummaryData} />
+          {!_.isEmpty(patientData) ? (
+            <PatientTable className="my-4" data={patientData} />
+          ) : (
+            <SimpleDataTable
+              className="my-4"
+              data={{ "No data found": "" }}
+              title={"Patient Information"}
+            />
+          )}
+          {!_.isEmpty(treatmentVolumesData) ? (
+            <TreatmentVolumeTable
+              className="my-4"
+              data={treatmentVolumesData}
+            />
+          ) : (
+            <SimpleDataTable
+              className="my-4"
+              data={{ "No data found": "" }}
+              title={"Radiotherapy Volumes (Targets)"}
+            />
+          )}
+          {!_.isEmpty(treatmentPhaseData) ? (
+            <TreatmentPhaseTable className="my-4" data={treatmentPhaseData} />
+          ) : (
+            <SimpleDataTable
+              className="my-4"
+              data={{ "No data found": "" }}
+              title={"Phase"}
+            />
+          )}
+          {!_.isEmpty(plannedTreatmentPhaseData) ? (
+            <PlannedTreatmentPhaseTable
+              className="my-4"
+              data={plannedTreatmentPhaseData}
+            />
+          ) : (
+            <SimpleDataTable
+              className="my-4"
+              data={{ "No data found": "" }}
+              title={"Planned Phase"}
+            />
+          )}
+          {!_.isEmpty(plannedCourseData) ? (
+            <PlannedCourseTable className="my-4" data={plannedCourseData} />
+          ) : (
+            <SimpleDataTable
+              className="my-4"
+              data={{ "No data found": "" }}
+              title={"Planned Course"}
+            />
+          )}
+          {!_.isEmpty(courseSummaryData) ? (
+            <CourseSummaryTable className="my-4" data={courseSummaryData} />
+          ) : (
+            <SimpleDataTable
+              className="my-4"
+              data={{ "No data found": "" }}
+              title={"Course Summary"}
+            />
+          )}
         </>
       )}
     </>

--- a/src/components/DataView/EmptyDataTable.js
+++ b/src/components/DataView/EmptyDataTable.js
@@ -1,0 +1,13 @@
+import SimpleDataTable from "./SimpleDataTable";
+
+function EmptyDataTable({ title, className }) {
+  return (
+    <SimpleDataTable
+      className={className}
+      data={{ "No data found": "" }}
+      title={title}
+    />
+  );
+}
+
+export default EmptyDataTable;

--- a/src/components/DataView/ProfileVisualizers/CourseSummaryTable.js
+++ b/src/components/DataView/ProfileVisualizers/CourseSummaryTable.js
@@ -1,7 +1,12 @@
 import SimpleDataTable from "../SimpleDataTable";
 import MultiEntryDataTable from "../MultiEntryDataTable";
+import EmptyDataTable from "../EmptyDataTable";
+import _ from "lodash";
 
 function CourseSummaryTable({ data = [], className }) {
+  if (_.isEmpty(data)) {
+    return <EmptyDataTable title="Course Summary" className={className} />;
+  }
   return data.map((courseSummary, i) => {
     const title = `Course Summary ${i + 1}`;
     const numVolumes =

--- a/src/components/DataView/ProfileVisualizers/PatientTable.js
+++ b/src/components/DataView/ProfileVisualizers/PatientTable.js
@@ -1,6 +1,11 @@
 import SimpleDataTable from "../SimpleDataTable";
+import EmptyDataTable from "../EmptyDataTable";
+import _ from "lodash";
 
 function PatientTable({ data = {}, className }) {
+  if (_.isEmpty(data)) {
+    return <EmptyDataTable title="Patient Information" className={className} />;
+  }
   return (
     <SimpleDataTable
       data={data}

--- a/src/components/DataView/ProfileVisualizers/PlannedCourseTable.js
+++ b/src/components/DataView/ProfileVisualizers/PlannedCourseTable.js
@@ -1,7 +1,12 @@
 import SimpleDataTable from "../SimpleDataTable";
 import MultiEntryDataTable from "../MultiEntryDataTable";
+import EmptyDataTable from "../EmptyDataTable";
+import _ from "lodash";
 
 function PlannedCourseTable({ data = [], className }) {
+  if (_.isEmpty(data)) {
+    return <EmptyDataTable title="Planned Course" className={className} />;
+  }
   return data.map((plannedCourse, i) => {
     const title = `Planned Course ${i + 1}`;
     const numVolumes =

--- a/src/components/DataView/ProfileVisualizers/PlannedTreatmentPhaseTable.js
+++ b/src/components/DataView/ProfileVisualizers/PlannedTreatmentPhaseTable.js
@@ -1,8 +1,12 @@
 import _ from "lodash";
 import SimpleDataTable from "../SimpleDataTable";
 import MultiEntryDataTable from "../MultiEntryDataTable";
+import EmptyDataTable from "../EmptyDataTable";
 
 function PlannedTreatmentPhaseTable({ data = [], className }) {
+  if (_.isEmpty(data)) {
+    return <EmptyDataTable title="Planned Phase" className={className} />;
+  }
   return data.map((plannedPhase, i) => {
     const title = `Planned Phase ${i + 1}`;
     // Compact so we don't make space for empty entries

--- a/src/components/DataView/ProfileVisualizers/TreatmentPhaseTable.js
+++ b/src/components/DataView/ProfileVisualizers/TreatmentPhaseTable.js
@@ -1,8 +1,12 @@
 import _ from "lodash";
 import SimpleDataTable from "../SimpleDataTable";
 import MultiEntryDataTable from "../MultiEntryDataTable";
+import EmptyDataTable from "../EmptyDataTable";
 
 function TreatmentPhaseTable({ data = [], className }) {
+  if (_.isEmpty(data)) {
+    return <EmptyDataTable title="Phase" className={className} />;
+  }
   return data.map((treatmentPhase, i) => {
     const title = `Phase ${i + 1}`;
     // Compact so we don't make space for empty entries

--- a/src/components/DataView/ProfileVisualizers/TreatmentVolumeTable.js
+++ b/src/components/DataView/ProfileVisualizers/TreatmentVolumeTable.js
@@ -1,6 +1,16 @@
 import MultiEntryDataTable from "../MultiEntryDataTable";
+import EmptyDataTable from "../EmptyDataTable";
+import _ from "lodash";
 
 function TreatmentVolumeTable({ data = [], className }) {
+  if (_.isEmpty(data)) {
+    return (
+      <EmptyDataTable
+        title="Radiotherapy Volumes (Targets)"
+        className={className}
+      />
+    );
+  }
   return (
     <MultiEntryDataTable
       dataArray={data}


### PR DESCRIPTION
STEAM-875

As a way to make it clear when data is missing, if any table has empty data, the table header will still appear with the message "No data found" under it. This can be seen in Patient-XRTS-01 and 02 who both don't have Planned Phase or Planned Course.

Let me know if this approach looks good. I considered a few different options, but I think keeping the table headers looks most consistent with the rest of the app without adding any new/redundant headers above the tables.