### PR TITLE
Updating body site mapping for phases and course summaries

### DIFF
--- a/src/components/DataView/ProfileVisualizers/CourseSummaryTable.js
+++ b/src/components/DataView/ProfileVisualizers/CourseSummaryTable.js
@@ -19,13 +19,13 @@ function CourseSummaryTable({ data = [], className }) {
           courseSummary["Number of Delivered Fractions"][i],
         "Total Delivered Dose [cGy]":
           courseSummary["Total Delivered Dose [cGy]"][i],
-        "Body Sites": courseSummary["Body Sites"][i],
+        Volumes: courseSummary["Volumes"][i],
       });
     }
     const courseData = { ...courseSummary };
     delete courseData["Number of Delivered Fractions"];
     delete courseData["Total Delivered Dose [cGy]"];
-    delete courseData["Body Sites"];
+    delete courseData["Volumes"];
     return (
       <div key={i} className={className}>
         {/* Display the base course data with a simple table */}

--- a/src/components/DataView/ProfileVisualizers/CourseSummaryTable.js
+++ b/src/components/DataView/ProfileVisualizers/CourseSummaryTable.js
@@ -19,13 +19,13 @@ function CourseSummaryTable({ data = [], className }) {
           courseSummary["Number of Delivered Fractions"][i],
         "Total Delivered Dose [cGy]":
           courseSummary["Total Delivered Dose [cGy]"][i],
-        Volumes: courseSummary["Volumes"][i],
+        Volume: courseSummary["Volume"][i],
       });
     }
     const courseData = { ...courseSummary };
     delete courseData["Number of Delivered Fractions"];
     delete courseData["Total Delivered Dose [cGy]"];
-    delete courseData["Volumes"];
+    delete courseData["Volume"];
     return (
       <div key={i} className={className}>
         {/* Display the base course data with a simple table */}

--- a/src/components/DataView/ProfileVisualizers/PlannedCourseTable.js
+++ b/src/components/DataView/ProfileVisualizers/PlannedCourseTable.js
@@ -19,13 +19,13 @@ function PlannedCourseTable({ data = [], className }) {
           plannedCourse["Number of Planned Fractions"][i],
         "Total Planned Dose [cGy]":
           plannedCourse["Total Planned Dose [cGy]"][i],
-        "Body Sites": plannedCourse["Body Sites"][i],
+        Volumes: plannedCourse["Volumes"][i],
       });
     }
     const plannedCourseData = { ...plannedCourse };
     delete plannedCourseData["Number of Planned Fractions"];
     delete plannedCourseData["Total Planned Dose [cGy]"];
-    delete plannedCourseData["Body Sites"];
+    delete plannedCourseData["Volumes"];
     return (
       <div key={i} className={className}>
         {/* Display the base course data with a simple table */}

--- a/src/components/DataView/ProfileVisualizers/PlannedCourseTable.js
+++ b/src/components/DataView/ProfileVisualizers/PlannedCourseTable.js
@@ -19,13 +19,13 @@ function PlannedCourseTable({ data = [], className }) {
           plannedCourse["Number of Planned Fractions"][i],
         "Total Planned Dose [cGy]":
           plannedCourse["Total Planned Dose [cGy]"][i],
-        Volumes: plannedCourse["Volumes"][i],
+        Volume: plannedCourse["Volume"][i],
       });
     }
     const plannedCourseData = { ...plannedCourse };
     delete plannedCourseData["Number of Planned Fractions"];
     delete plannedCourseData["Total Planned Dose [cGy]"];
-    delete plannedCourseData["Volumes"];
+    delete plannedCourseData["Volume"];
     return (
       <div key={i} className={className}>
         {/* Display the base course data with a simple table */}

--- a/src/components/DataView/ProfileVisualizers/PlannedTreatmentPhaseTable.js
+++ b/src/components/DataView/ProfileVisualizers/PlannedTreatmentPhaseTable.js
@@ -19,13 +19,13 @@ function PlannedTreatmentPhaseTable({ data = [], className }) {
         "Planned Dose per Fraction [cGy]":
           plannedPhase["Planned Dose per Fraction [cGy]"][i],
         "Total Planned Dose [cGy]": plannedPhase["Total Planned Dose [cGy]"][i],
-        "Body Sites": plannedPhase["Body Sites"][i],
+        Volumes: plannedPhase["Volumes"][i],
       });
     }
     const plannedPhaseData = { ...plannedPhase };
     delete plannedPhaseData["Planned Dose per Fraction [cGy]"];
     delete plannedPhaseData["Total Planned Dose [cGy]"];
-    delete plannedPhaseData["Body Sites"];
+    delete plannedPhaseData["Volumes"];
     return (
       <div className={className} key={i}>
         {/* Display the base phase data with a simple table */}

--- a/src/components/DataView/ProfileVisualizers/PlannedTreatmentPhaseTable.js
+++ b/src/components/DataView/ProfileVisualizers/PlannedTreatmentPhaseTable.js
@@ -19,13 +19,13 @@ function PlannedTreatmentPhaseTable({ data = [], className }) {
         "Planned Dose per Fraction [cGy]":
           plannedPhase["Planned Dose per Fraction [cGy]"][i],
         "Total Planned Dose [cGy]": plannedPhase["Total Planned Dose [cGy]"][i],
-        Volumes: plannedPhase["Volumes"][i],
+        Volume: plannedPhase["Volume"][i],
       });
     }
     const plannedPhaseData = { ...plannedPhase };
     delete plannedPhaseData["Planned Dose per Fraction [cGy]"];
     delete plannedPhaseData["Total Planned Dose [cGy]"];
-    delete plannedPhaseData["Volumes"];
+    delete plannedPhaseData["Volume"];
     return (
       <div className={className} key={i}>
         {/* Display the base phase data with a simple table */}

--- a/src/components/DataView/ProfileVisualizers/TreatmentPhaseTable.js
+++ b/src/components/DataView/ProfileVisualizers/TreatmentPhaseTable.js
@@ -18,12 +18,12 @@ function TreatmentPhaseTable({ data = [], className }) {
       volumesData.push({
         "Total Dose Delivered [cGy]":
           treatmentPhase["Total Dose Delivered [cGy]"][i],
-        Volumes: treatmentPhase["Volumes"][i],
+        Volume: treatmentPhase["Volume"][i],
       });
     }
     const treatmentPhaseData = { ...treatmentPhase };
     delete treatmentPhaseData["Total Dose Delivered [cGy]"];
-    delete treatmentPhaseData["Volumes"];
+    delete treatmentPhaseData["Volume"];
     return (
       <div className={className} key={i}>
         {/* Display the base phase data with a simple table */}

--- a/src/components/DataView/ProfileVisualizers/TreatmentPhaseTable.js
+++ b/src/components/DataView/ProfileVisualizers/TreatmentPhaseTable.js
@@ -18,11 +18,12 @@ function TreatmentPhaseTable({ data = [], className }) {
       volumesData.push({
         "Total Dose Delivered [cGy]":
           treatmentPhase["Total Dose Delivered [cGy]"][i],
-        "Body Sites": treatmentPhase["Body Sites"][i],
+        Volumes: treatmentPhase["Volumes"][i],
       });
     }
     const treatmentPhaseData = { ...treatmentPhase };
     delete treatmentPhaseData["Total Dose Delivered [cGy]"];
+    delete treatmentPhaseData["Volumes"];
     return (
       <div className={className} key={i}>
         {/* Display the base phase data with a simple table */}

--- a/src/lib/mappingUtils.js
+++ b/src/lib/mappingUtils.js
@@ -23,9 +23,6 @@ function getTechniques(resource, resourceType) {
     )
     .join("\n");
 }
-function getBodySites(resource, resourceType) {
-  return fhirpath.evaluate(resource, `${resourceType}.bodySite.coding.display`);
-}
 
 /**
  * Takes a patient resource returned by makeRequests and returns a mapping of Patient data to be displayed in the table
@@ -77,7 +74,10 @@ function mapCourseSummary(procedure) {
       summary,
       "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-dose-delivered-to-volume').extension.where(url = 'totalDoseDelivered').valueQuantity.value"
     );
-    output["Body Sites"] = getBodySites(summary, "Procedure");
+    output["Body Sites"] = fhirpath.evaluate(
+      summary,
+      "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-dose-delivered-to-volume').extension.where(url = 'volume').valueReference.display"
+    );
     outputs.push(output);
   });
   return outputs;
@@ -111,7 +111,10 @@ function mapTreatedPhase(procedure) {
       phase,
       "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-dose-delivered-to-volume').extension.where(url = 'totalDoseDelivered').valueQuantity.value"
     );
-    output["Body Sites"] = getBodySites(phase, "Procedure");
+    output["Body Sites"] = fhirpath.evaluate(
+      phase,
+      "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-dose-delivered-to-volume').extension.where(url = 'volume').valueReference.display"
+    );
     outputs.push(output);
   });
   return outputs;
@@ -151,7 +154,10 @@ function mapPlannedTreatmentPhases(serviceRequests) {
       plannedPhase,
       "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-dose-planned-to-volume').extension.where(url = 'totalDose').valueQuantity.value"
     );
-    output["Body Sites"] = getBodySites(plannedPhase, "ServiceRequest");
+    output["Body Sites"] = fhirpath.evaluate(
+      plannedPhase,
+      "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-dose-planned-to-volume').extension.where(url = 'volume').valueReference.display"
+    );
     outputs.push(output);
   });
   return outputs;
@@ -198,7 +204,10 @@ function mapPlannedCourses(serviceRequests) {
       plannedCourse,
       "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-dose-planned-to-volume').extension.where(url = 'totalDose').valueQuantity.value"
     );
-    output["Body Sites"] = getBodySites(plannedCourse, "ServiceRequest");
+    output["Body Sites"] = fhirpath.evaluate(
+      plannedCourse,
+      "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-dose-planned-to-volume').extension.where(url = 'volume').valueReference.display"
+    );
     //NOT included yet
     // output["Energy or Isotope"]
     // output["Treatment Device"]

--- a/src/lib/mappingUtils.js
+++ b/src/lib/mappingUtils.js
@@ -77,7 +77,7 @@ function mapCourseSummary(procedure) {
       summary,
       "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-dose-delivered-to-volume').extension.where(url = 'totalDoseDelivered').valueQuantity.value"
     );
-    output["Volumes"] = fhirpath.evaluate(
+    output["Volume"] = fhirpath.evaluate(
       summary,
       "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-dose-delivered-to-volume').extension.where(url = 'volume').valueReference.display"
     );
@@ -115,7 +115,7 @@ function mapTreatedPhase(procedure) {
       phase,
       "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-dose-delivered-to-volume').extension.where(url = 'totalDoseDelivered').valueQuantity.value"
     );
-    output["Volumes"] = fhirpath.evaluate(
+    output["Volume"] = fhirpath.evaluate(
       phase,
       "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-dose-delivered-to-volume').extension.where(url = 'volume').valueReference.display"
     );
@@ -159,7 +159,7 @@ function mapPlannedTreatmentPhases(serviceRequests) {
       plannedPhase,
       "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-dose-planned-to-volume').extension.where(url = 'totalDose').valueQuantity.value"
     );
-    output["Volumes"] = fhirpath.evaluate(
+    output["Volume"] = fhirpath.evaluate(
       plannedPhase,
       "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-dose-planned-to-volume').extension.where(url = 'volume').valueReference.display"
     );
@@ -210,7 +210,7 @@ function mapPlannedCourses(serviceRequests) {
       plannedCourse,
       "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-dose-planned-to-volume').extension.where(url = 'totalDose').valueQuantity.value"
     );
-    output["Volumes"] = fhirpath.evaluate(
+    output["Volume"] = fhirpath.evaluate(
       plannedCourse,
       "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-dose-planned-to-volume').extension.where(url = 'volume').valueReference.display"
     );

--- a/src/lib/mappingUtils.js
+++ b/src/lib/mappingUtils.js
@@ -23,6 +23,9 @@ function getTechniques(resource, resourceType) {
     )
     .join("\n");
 }
+function getBodySites(resource, resourceType) {
+  return fhirpath.evaluate(resource, `${resourceType}.bodySite.coding.display`);
+}
 
 /**
  * Takes a patient resource returned by makeRequests and returns a mapping of Patient data to be displayed in the table
@@ -74,10 +77,11 @@ function mapCourseSummary(procedure) {
       summary,
       "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-dose-delivered-to-volume').extension.where(url = 'totalDoseDelivered').valueQuantity.value"
     );
-    output["Body Sites"] = fhirpath.evaluate(
+    output["Volumes"] = fhirpath.evaluate(
       summary,
       "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-dose-delivered-to-volume').extension.where(url = 'volume').valueReference.display"
     );
+    output["Body Sites"] = getBodySites(summary, "Procedure");
     outputs.push(output);
   });
   return outputs;
@@ -111,10 +115,11 @@ function mapTreatedPhase(procedure) {
       phase,
       "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-dose-delivered-to-volume').extension.where(url = 'totalDoseDelivered').valueQuantity.value"
     );
-    output["Body Sites"] = fhirpath.evaluate(
+    output["Volumes"] = fhirpath.evaluate(
       phase,
       "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-dose-delivered-to-volume').extension.where(url = 'volume').valueReference.display"
     );
+    output["Body Sites"] = getBodySites(phase, "Procedure");
     outputs.push(output);
   });
   return outputs;
@@ -154,10 +159,11 @@ function mapPlannedTreatmentPhases(serviceRequests) {
       plannedPhase,
       "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-dose-planned-to-volume').extension.where(url = 'totalDose').valueQuantity.value"
     );
-    output["Body Sites"] = fhirpath.evaluate(
+    output["Volumes"] = fhirpath.evaluate(
       plannedPhase,
       "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-dose-planned-to-volume').extension.where(url = 'volume').valueReference.display"
     );
+    output["Body Sites"] = getBodySites(plannedPhase, "ServiceRequest");
     outputs.push(output);
   });
   return outputs;
@@ -204,10 +210,11 @@ function mapPlannedCourses(serviceRequests) {
       plannedCourse,
       "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-dose-planned-to-volume').extension.where(url = 'totalDose').valueQuantity.value"
     );
-    output["Body Sites"] = fhirpath.evaluate(
+    output["Volumes"] = fhirpath.evaluate(
       plannedCourse,
       "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-dose-planned-to-volume').extension.where(url = 'volume').valueReference.display"
     );
+    output["Body Sites"] = getBodySites(plannedCourse, "ServiceRequest");
     //NOT included yet
     // output["Energy or Isotope"]
     // output["Treatment Device"]


### PR DESCRIPTION
This PR updates body site mapping by pulling the value for body site from the `mcode-radiotherapy-dose-delivered-to-volume` and `codexrt-radiotherapy-dose-planned-to-volume` extensions so the values get properly mapped in the "Dose Delivered to Volume" sub-tables.

To test, run the app and see that "Dose Delivered to Volume" sub-tables with multiple entries no longer have "N/A" for some entries. For example Phase 1 on Patient-XRTS-04-22A previously had "Breast structure (body structure), N/A" and should now have "Left Breast, Left Breast Boost"

Also, I noticed that Phase tables have Body Sites in the main and sub-tables. Is it necessary to have Body Sites twice on these tables? Now that we are properly mapping multiple body sites, the Body Sites in the main table ends up smashing all the values together (again if you look at Patient-XRTS-04-22A, you'll see the Body Sites in the main table as "Left BreastLeft Breast Boost"). I wanted to check if we do really want Body Sites twice in that table before I went in and fixed this