### PR TITLE
Steam 970/null guarding

### DIFF
--- a/src/lib/mappingUtils.js
+++ b/src/lib/mappingUtils.js
@@ -56,7 +56,6 @@ function mapCourseSummary(procedure) {
   const outputs = [];
   summaries.forEach((summary) => {
     const output = {};
-    delete summary.performedPeriod;
     output["Course Label"] = summary?.identifier?.[0]?.value ?? "N/A";
     output["Treatment Status"] = summary?.status;
     output["Treatment Intent"] = getProcedureIntent(summary, "Procedure");

--- a/src/lib/mappingUtils.js
+++ b/src/lib/mappingUtils.js
@@ -34,12 +34,12 @@ function getBodySites(resource, resourceType) {
  */
 function mapPatient(patient) {
   const output = {};
-  output["ID"] = patient.identifier[0].value;
-  output["First Name"] = patient.name[0].given.join(" ");
-  output["Last Name"] = patient.name[0].family;
-  output["Date of Birth"] = patient.birthDate;
-  output["Administrative Gender"] = patient.gender;
-  output["Birth Sex"] = "N/A"; //patient.extension[0].valueCode;
+  output["ID"] = patient?.identifier?.[0]?.value;
+  output["First Name"] = patient?.name?.[0]?.given.join(" ");
+  output["Last Name"] = patient?.name?.[0]?.family;
+  output["Date of Birth"] = patient?.birthDate;
+  output["Administrative Gender"] = patient?.gender;
+  output["Birth Sex"] = "N/A"; //patient?.extension[0].valueCode;
   return output;
 }
 
@@ -56,13 +56,12 @@ function mapCourseSummary(procedure) {
   const outputs = [];
   summaries.forEach((summary) => {
     const output = {};
-    output["Course Label"] = summary.identifier
-      ? summary.identifier[0].value
-      : "N/A";
-    output["Treatment Status"] = summary.status;
+    delete summary.performedPeriod;
+    output["Course Label"] = summary?.identifier?.[0]?.value ?? "N/A";
+    output["Treatment Status"] = summary?.status;
     output["Treatment Intent"] = getProcedureIntent(summary, "Procedure");
-    output["Start Date"] = summary.performedPeriod.start;
-    output["End Date"] = summary.performedPeriod.end;
+    output["Start Date"] = summary?.performedPeriod?.start;
+    output["End Date"] = summary?.performedPeriod?.end;
     output["Modalities"] = getModalities(summary, "Procedure");
     output["Techniques"] = getTechniques(summary, "Procedure");
     output["Number of Sessions"] = fhirpath.evaluate(
@@ -100,11 +99,9 @@ function mapTreatedPhase(procedure) {
   const outputs = [];
   phases.forEach((phase) => {
     const output = {};
-    output["Phase Label"] = phase.identifier
-      ? phase.identifier[0].value
-      : "N/A";
-    output["Start Date"] = phase.performedPeriod.start;
-    output["End Date"] = phase.performedPeriod.end;
+    output["Phase Label"] = phase?.identifier?.[0]?.value ?? "N/A";
+    output["Start Date"] = phase?.performedPeriod?.start;
+    output["End Date"] = phase?.performedPeriod?.end;
     output["Modalities"] = getModalities(phase, "Procedure");
     output["Techniques"] = getTechniques(phase, "Procedure");
     output["Number of Fractions Delivered"] = fhirpath.evaluate(
@@ -139,11 +136,10 @@ function mapPlannedTreatmentPhases(serviceRequests) {
   const outputs = [];
   plannedPhases.forEach((plannedPhase) => {
     const output = {};
-    output["Planned Phase Label"] = plannedPhase.identifier
-      ? plannedPhase.identifier[0].value
-      : "N/A";
-    output["Phase Status"] = plannedPhase.status;
-    output["Request Intent"] = plannedPhase.intent;
+    output["Planned Phase Label"] =
+      plannedPhase?.identifier?.[0]?.value ?? "N/A";
+    output["Phase Status"] = plannedPhase?.status;
+    output["Request Intent"] = plannedPhase?.intent;
     // IG states there will be at most one procedure intent
     output["Modalities"] = getModalities(plannedPhase, "ServiceRequest");
     output["Techniques"] = getTechniques(plannedPhase, "ServiceRequest");
@@ -183,11 +179,9 @@ function mapPlannedCourses(serviceRequests) {
   const outputs = [];
   plannedCourses.forEach((plannedCourse) => {
     const output = {};
-    output["Course Label"] = plannedCourse.identifier
-      ? plannedCourse.identifier[0].value
-      : "N/A";
-    output["Course Status"] = plannedCourse.status;
-    output["Request Intent"] = plannedCourse.intent;
+    output["Course Label"] = plannedCourse?.identifier?.[0]?.value && "N/A";
+    output["Course Status"] = plannedCourse?.status;
+    output["Request Intent"] = plannedCourse?.intent;
     // IG states there will be at most one procedure intent
     output["Procedure Intent"] = getProcedureIntent(
       plannedCourse,
@@ -238,15 +232,10 @@ function mapVolumes(volumes) {
       volume,
       "BodyStructure.identifier.where(use = 'usual').value"
     )[0];
-    output["Type"] = volume.morphology
-      ? volume.morphology.coding[0].display
-      : undefined;
-    output["Location"] = volume.location
-      ? volume.location.coding[0].display
-      : undefined;
-    output["Location Qualifier"] = volume.locationQualifier
-      ? volume.locationQualifier[0].coding[0].display
-      : undefined;
+    output["Type"] = volume?.morphology?.coding?.[0]?.display ?? undefined;
+    output["Location"] = volume?.location?.coding?.[0]?.display ?? undefined;
+    output["Location Qualifier"] =
+      volume?.locationQualifier?.[0]?.coding?.[0]?.display ?? undefined;
     outputs.push(output);
   });
   return outputs;


### PR DESCRIPTION
Adds null guarding for all FHIR values we map in `mappingUtils.js` by leveraging the [optional chaining operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining). Additionally, we use the [nullish coalescing operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator) to provide default values in the event the values aren't defined. 

To test: 
- Failure Case: remove the optional chaining operators from the courseSummary mappings of `output["Start Date"]` and `output["End Date"]`. Before you start mapping from the `summary` object, delete the `performedPeriod`property from the object. Confirm that, under these conditions, the page won't load, logging an error to the console. 
- Positive case: Add back the optional chaining, but leave the property deletion. Confirm that now the pages will load.