### PR TITLE
Request Headers

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,6 +22,8 @@ import DataView from "./components/DataView/DataView";
 import Header from "./components/Header";
 import LoadingAnimation from "./components/LoadingAnimation";
 import RequestForm from "./components/RequestForm/RequestForm";
+import HeaderForm from "./components/HeaderForm/HeaderForm";
+import RequestHeadersList from "./components/HeaderForm/RequestHeadersList";
 
 const BASE_URL = "https://api.logicahealth.org/RTTD/open";
 
@@ -31,6 +33,10 @@ function App() {
   const [resourceMap, setResourceMap] = useState(new Map());
   const [searchedPatientIds, setSearchedPatientIds] = useState([]);
   const [showRequestForm, setShowRequestForm] = useState(false);
+  const [showHeaderForm, setShowHeaderForm] = useState(false);
+  const [currentHeaderSet, setCurrentHeaderSet] = useState([]);
+  const [requestHeaders, setRequestHeaders] = useState({});
+  const [currentHeaderKey, setCurrentHeaderKey] = useState();
   const [currentPatientQuery, setCurrentPatientQuery] = useState({});
   const [currentPatientQueryIdx, setCurrentPatientQueryIdx] = useState();
   const [patientQueries, setPatientQueries] = useState([
@@ -90,6 +96,12 @@ function App() {
     setShowRequestForm(true);
   }
 
+  function openHeaderForm(headerSet) {
+    setCurrentHeaderSet(headerSet);
+    setCurrentHeaderKey(headerSet[0]);
+    setShowHeaderForm(true);
+  }
+
   /**
    * Creates a map with each patient Id as a key, and an array of corresponding resources as the value.
    * Logs the resulting map to the console
@@ -102,13 +114,22 @@ function App() {
     );
 
     // Compact the return result to remove empty values
-    const patientResources = await fetchPatients(searchQueries).then(
-      (patients) => _.compact(patients)
-    );
+    const patientResources = await fetchPatients(
+      searchQueries,
+      requestHeaders
+    ).then((patients) => _.compact(patients));
     for (const patient of patientResources) {
-      const procedures = await fetchProcedures(serverUrl, patient.id);
-      const volumes = await fetchVolumes(serverUrl, patient.id);
-      const serviceRequests = await fetchServiceRequests(serverUrl, patient.id);
+      const procedures = await fetchProcedures(
+        serverUrl,
+        patient.id,
+        requestHeaders
+      );
+      const volumes = await fetchVolumes(serverUrl, patient.id, requestHeaders);
+      const serviceRequests = await fetchServiceRequests(
+        serverUrl,
+        patient.id,
+        requestHeaders
+      );
       resourceMap.set(patient.id, [
         mapPatient(patient),
         mapTreatedPhase(procedures),
@@ -134,6 +155,29 @@ function App() {
           />
           <span className="flex text-base last:border-b-0 w-full justify-between items-center">
             <label className="text-lg mb-1" htmlFor="patientQueries">
+              Request Headers
+            </label>
+            <button
+              type="button"
+              className="flex"
+              onClick={(e) => {
+                openHeaderForm([]);
+              }}
+            >
+              <Plus className="inline m-2" size={24} />
+            </button>
+          </span>
+          {Object.entries(requestHeaders).length > 0 ? (
+            <RequestHeadersList
+              requestHeader={requestHeaders}
+              setRequestHeaders={setRequestHeaders}
+              openHeaderForm={openHeaderForm}
+            />
+          ) : (
+            <p className="text-md text-center italic">No request headers</p>
+          )}
+          <span className="flex text-base last:border-b-0 w-full justify-between items-center">
+            <label className="text-lg mb-1" htmlFor="patientQueries">
               Patient Queries
             </label>
             <button
@@ -146,19 +190,27 @@ function App() {
               <Plus className="inline m-2" size={24} />
             </button>
           </span>
-          <PatientQueryList
-            patientQueries={patientQueries}
-            setPatientQueries={setPatientQueries}
-            setCurrentPatientQuery={setCurrentPatientQuery}
-            openRequestForm={openRequestForm}
-          />
+          {patientQueries.length > 0 ? (
+            <PatientQueryList
+              patientQueries={patientQueries}
+              setPatientQueries={setPatientQueries}
+              setCurrentPatientQuery={setCurrentPatientQuery}
+              openRequestForm={openRequestForm}
+              id="patientQueries"
+            />
+          ) : (
+            <p className="text-md text-center italic">
+              Please create a patient query
+            </p>
+          )}
           <button
-            className="my-4 p-2 border border-gray-400 bg-slate-100 hover:bg-slate-200 cursor-pointer transition-all shadow-lg active:shadow "
+            className="my-4 p-2 border border-gray-400 bg-slate-100 hover:bg-slate-200 disabled:bg-slate-200 cursor-pointer disabled:cursor-not-allowed transition-all shadow-lg active:shadow "
             onClick={async (e) => {
               setLoading(true);
               await makeRequests();
               setLoading(false);
             }}
+            disabled={patientQueries.length === 0}
           >
             Fetch Treatment Summaries
           </button>
@@ -185,6 +237,16 @@ function App() {
           setDisplay={setShowRequestForm}
           currentPatientQueryIdx={currentPatientQueryIdx}
           setCurrentPatientQueryIdx={setCurrentPatientQueryIdx}
+        />
+      )}
+      {showHeaderForm && (
+        <HeaderForm
+          currentHeaderSet={currentHeaderSet}
+          requestHeaders={requestHeaders}
+          setRequestHeaders={setRequestHeaders}
+          setDisplay={setShowHeaderForm}
+          setCurrentHeaderSet={setCurrentHeaderSet}
+          currentHeaderKey={currentHeaderKey}
         />
       )}
     </>

--- a/src/components/HeaderForm/HeaderForm.js
+++ b/src/components/HeaderForm/HeaderForm.js
@@ -1,30 +1,55 @@
-function HeaderForm({
-  currentHeaderSet,
-  requestHeaders,
-  setRequestHeaders,
-  setDisplay,
-  setCurrentHeaderSet,
-  currentHeaderKey,
-}) {
+import { Fragment, useState } from "react";
+import { Trash, Plus } from "react-feather";
+
+function HeaderForm({ requestHeaders, setRequestHeaders, setDisplay }) {
+  const [editedRequestHeaders, setEditedRequestHeaders] = useState([
+    ...requestHeaders,
+  ]);
+
   function handleClose() {
     setDisplay(false);
   }
 
+  function addHeader() {
+    const modifiedHeadersArr = [...editedRequestHeaders];
+    modifiedHeadersArr.push(["", ""]);
+    setEditedRequestHeaders(modifiedHeadersArr);
+  }
+
+  function removeHeader(idx) {
+    let modifiedHeadersArr = [...editedRequestHeaders];
+    modifiedHeadersArr.splice(idx, 1);
+    setEditedRequestHeaders(modifiedHeadersArr);
+  }
+
   function handleKeyChange(e) {
+    // Update relevant tuple
     let value = e.target.value;
-    setCurrentHeaderSet([value, currentHeaderSet[1]]);
+    let changedSetIdx = e.target.id.replace("requestkey-", "");
+    const changedSet = [...editedRequestHeaders[changedSetIdx]];
+    changedSet[0] = value;
+
+    // Update request headers prop
+    let modifiedHeadersArr = [...editedRequestHeaders];
+    modifiedHeadersArr.splice(changedSetIdx, 1, changedSet);
+    setEditedRequestHeaders(modifiedHeadersArr);
   }
 
   function handleValueChange(e) {
+    // Update relevant tuple
     let value = e.target.value;
-    setCurrentHeaderSet([currentHeaderSet[0], value]);
+    let changedSetIdx = e.target.id.replace("requestvalue-", "");
+    const changedSet = [...editedRequestHeaders[changedSetIdx]];
+    changedSet[1] = value;
+
+    // Update request headers prop
+    let modifiedHeadersArr = [...editedRequestHeaders];
+    modifiedHeadersArr.splice(changedSetIdx, 1, changedSet);
+    setEditedRequestHeaders(modifiedHeadersArr);
   }
 
   function saveHeader() {
-    const headerObj = { ...requestHeaders };
-    delete headerObj[currentHeaderKey];
-    headerObj[currentHeaderSet[0]] = currentHeaderSet[1];
-    setRequestHeaders(headerObj);
+    setRequestHeaders(editedRequestHeaders);
     handleClose();
   }
   return (
@@ -35,42 +60,74 @@ function HeaderForm({
       >
         <div
           style={{ borderWidth: "1px" }}
-          className="lg:w-4/12 p-3 rounded-lg border-black bg-white"
+          className="lg:w-4/12 p-3 rounded-lg border-black bg-white max-h-fit"
           onMouseDown={(e) => e.stopPropagation()}
         >
-          <div className="grid grid-cols-2">
-            <label className="text-center text-lg mb-1" htmlFor="key-input">
+          <div className="grid grid-cols-12 ">
+            <label
+              className="text-center text-lg mb-1 col-span-5"
+              htmlFor="key-input"
+            >
               Key
             </label>
-            <label className="text-center text-lg mb-1" htmlFor="value-input">
+            <label
+              className="text-center text-lg mb-1 col-span-6"
+              htmlFor="value-input"
+            >
               Value
             </label>
+            <Plus className="inline ml-3" size={24} onClick={addHeader}></Plus>
           </div>
-          <div className="grid grid-cols-2">
-            <input
-              id="key-input"
-              type="text"
-              className="border border-slate-500 mr-4 mb-4 p-2"
-              placeholder="e.g. Content-Type"
-              value={currentHeaderSet[0] || ""}
-              onChange={handleKeyChange}
-            ></input>
-            <input
-              id="value-input"
-              type="text"
-              className="border border-slate-500 ml-4 mb-4 p-2"
-              placeholder="e.g. application/json"
-              value={currentHeaderSet[1] || ""}
-              onChange={handleValueChange}
-            ></input>
+          <hr></hr>
+          <div className="grid grid-cols-12 overflow-auto max-h-96 mt-4">
+            {editedRequestHeaders.length > 0 ? (
+              editedRequestHeaders.map(([key, value], idx) => {
+                return (
+                  <Fragment key={`headerfield-${idx}`}>
+                    <input
+                      id={`requestkey-${idx}`}
+                      type="text"
+                      key={`requestkey-${idx}`}
+                      className="border border-slate-500 mr-4 mb-4 p-2 col-span-5"
+                      placeholder="e.g. Content-Type"
+                      value={key || ""}
+                      onChange={handleKeyChange}
+                    ></input>
+                    <input
+                      id={`requestvalue-${idx}`}
+                      key={`requestvalue-${idx}`}
+                      type="text"
+                      className="border border-slate-500 ml-4 mb-4 p-2 col-span-6"
+                      placeholder="e.g. application/json"
+                      value={value || ""}
+                      onChange={handleValueChange}
+                    ></input>
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        removeHeader(idx);
+                      }}
+                    >
+                      <Trash className="inline mb-4" size={20} />
+                    </button>
+                  </Fragment>
+                );
+              })
+            ) : (
+              <p className={"text-lg col-span-12 text-center italic mb-4"}>
+                No header fields
+              </p>
+            )}
           </div>
-          <div className="flex justify-center items-center">
+          <hr></hr>
+          <div className="flex justify-center items-center mt-2">
             <button
               className="mx-2 border border-gray-400 px-1 hover:bg-slate-200 cursor-pointer transition-all shadow-lg active:shadow bg-slate-100"
               type="button"
               onClick={saveHeader}
             >
-              Save Header
+              Save Headers
             </button>
             <button
               type="button"

--- a/src/components/HeaderForm/HeaderForm.js
+++ b/src/components/HeaderForm/HeaderForm.js
@@ -76,7 +76,15 @@ function HeaderForm({ requestHeaders, setRequestHeaders, setDisplay }) {
             >
               Value
             </label>
-            <Plus className="inline ml-3" size={24} onClick={addHeader}></Plus>
+            <button
+              className="col-span-1 justify-center items-center"
+              onClick={(e) => {
+                e.preventDefault();
+                addHeader();
+              }}
+            >
+              <Plus className="inline" size={24}></Plus>
+            </button>
           </div>
           <hr></hr>
           <div className="grid grid-cols-12 overflow-auto max-h-96 mt-4 p-px">

--- a/src/components/HeaderForm/HeaderForm.js
+++ b/src/components/HeaderForm/HeaderForm.js
@@ -1,0 +1,91 @@
+function HeaderForm({
+  currentHeaderSet,
+  requestHeaders,
+  setRequestHeaders,
+  setDisplay,
+  setCurrentHeaderSet,
+  currentHeaderKey,
+}) {
+  function handleClose() {
+    setDisplay(false);
+  }
+
+  function handleKeyChange(e) {
+    let value = e.target.value;
+    setCurrentHeaderSet([value, currentHeaderSet[1]]);
+  }
+
+  function handleValueChange(e) {
+    let value = e.target.value;
+    setCurrentHeaderSet([currentHeaderSet[0], value]);
+  }
+
+  function saveHeader() {
+    const headerObj = { ...requestHeaders };
+    delete headerObj[currentHeaderKey];
+    headerObj[currentHeaderSet[0]] = currentHeaderSet[1];
+    setRequestHeaders(headerObj);
+    handleClose();
+  }
+  return (
+    <>
+      <div
+        onMouseDown={handleClose}
+        className="grid place-items-center absolute inset-0 outline-none overflow-x-hidden overflow-y-auto bg-gray-400/50"
+      >
+        <div
+          style={{ borderWidth: "1px" }}
+          className="lg:w-4/12 p-3 rounded-lg border-black bg-white"
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          <div className="grid grid-cols-2">
+            <label className="text-center text-lg mb-1" htmlFor="key-input">
+              Key
+            </label>
+            <label className="text-center text-lg mb-1" htmlFor="value-input">
+              Value
+            </label>
+          </div>
+          <div className="grid grid-cols-2">
+            <input
+              id="key-input"
+              type="text"
+              className="border border-slate-500 mr-4 mb-4 p-2"
+              placeholder="e.g. Content-Type"
+              value={currentHeaderSet[0] || ""}
+              onChange={handleKeyChange}
+            ></input>
+            <input
+              id="value-input"
+              type="text"
+              className="border border-slate-500 ml-4 mb-4 p-2"
+              placeholder="e.g. application/json"
+              value={currentHeaderSet[1] || ""}
+              onChange={handleValueChange}
+            ></input>
+          </div>
+          <div className="flex justify-center items-center">
+            <button
+              className="mx-2 border border-gray-400 px-1 hover:bg-slate-200 cursor-pointer transition-all shadow-lg active:shadow bg-slate-100"
+              type="button"
+              onClick={saveHeader}
+            >
+              Save Header
+            </button>
+            <button
+              type="button"
+              className="mx-2 border border-gray-400 px-1 hover:bg-red-300 cursor-pointer transition-all shadow-lg active:shadow bg-red-200"
+              onClick={(e) => {
+                handleClose();
+              }}
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default HeaderForm;

--- a/src/components/HeaderForm/HeaderForm.js
+++ b/src/components/HeaderForm/HeaderForm.js
@@ -79,7 +79,7 @@ function HeaderForm({ requestHeaders, setRequestHeaders, setDisplay }) {
             <Plus className="inline ml-3" size={24} onClick={addHeader}></Plus>
           </div>
           <hr></hr>
-          <div className="grid grid-cols-12 overflow-auto max-h-96 mt-4">
+          <div className="grid grid-cols-12 overflow-auto max-h-96 mt-4 p-px">
             {editedRequestHeaders.length > 0 ? (
               editedRequestHeaders.map(([key, value], idx) => {
                 return (
@@ -104,12 +104,13 @@ function HeaderForm({ requestHeaders, setRequestHeaders, setDisplay }) {
                     ></input>
                     <button
                       type="button"
+                      className="mb-4"
                       onClick={(e) => {
                         e.preventDefault();
                         removeHeader(idx);
                       }}
                     >
-                      <Trash className="inline mb-4" size={20} />
+                      <Trash className="inline" size={20} />
                     </button>
                   </Fragment>
                 );

--- a/src/components/HeaderForm/RequestHeadersList.js
+++ b/src/components/HeaderForm/RequestHeadersList.js
@@ -1,0 +1,56 @@
+import { Trash } from "react-feather";
+
+function RequestHeadersList({
+  requestHeader,
+  setRequestHeaders,
+  openHeaderForm,
+}) {
+  /**
+   * Remove a current query # from a list
+   * @param {int} index
+   * @returns nothing; sets state to update patientQueries
+   */
+  function removeHeader(key) {
+    const requestObj = { ...requestHeader };
+    delete requestObj[key];
+    setRequestHeaders(requestObj);
+  }
+
+  function handleHeaderSelection(key, value) {
+    openHeaderForm([key, value]);
+  }
+
+  return (
+    <ul className="max-h-96 overflow-y-auto">
+      {Object.entries(requestHeader).map(([key, value]) => {
+        return (
+          <li
+            className="flex text-base border border-b-0 last:border-b border-slate-500 w-full p-2 justify-between items-center"
+            key={key}
+          >
+            <button
+              type="button"
+              onClick={(e) => {
+                handleHeaderSelection(key, value);
+              }}
+            >
+              {`${key}: ${value}`}
+            </button>
+            <button
+              type="button"
+              className="flex"
+              // Inline click handler specific to this ith element
+              onClick={(e) => {
+                e.preventDefault();
+                removeHeader(key);
+              }}
+            >
+              <Trash className="inline" size={16} />
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+export default RequestHeadersList;

--- a/src/components/HeaderForm/RequestHeadersList.js
+++ b/src/components/HeaderForm/RequestHeadersList.js
@@ -1,29 +1,12 @@
-import { Trash } from "react-feather";
-
-function RequestHeadersList({
-  requestHeader,
-  setRequestHeaders,
-  openHeaderForm,
-}) {
-  /**
-   * Remove a current query # from a list
-   * @param {int} index
-   * @returns nothing; sets state to update patientQueries
-   */
-  function removeHeader(key) {
-    const requestObj = { ...requestHeader };
-    delete requestObj[key];
-    setRequestHeaders(requestObj);
-  }
-
-  function handleHeaderSelection(key, value) {
-    openHeaderForm([key, value]);
+function RequestHeadersList({ requestHeaders, openHeaderForm }) {
+  function handleHeaderSelection() {
+    openHeaderForm();
   }
 
   return (
     <ul className="max-h-96 overflow-y-auto">
-      {Object.entries(requestHeader).map(([key, value]) => {
-        return (
+      {requestHeaders.map(([key, value]) => {
+        return key && value ? (
           <li
             className="flex text-base border border-b-0 last:border-b border-slate-500 w-full p-2 justify-between items-center"
             key={key}
@@ -31,24 +14,13 @@ function RequestHeadersList({
             <button
               type="button"
               onClick={(e) => {
-                handleHeaderSelection(key, value);
+                handleHeaderSelection();
               }}
             >
               {`${key}: ${value}`}
             </button>
-            <button
-              type="button"
-              className="flex"
-              // Inline click handler specific to this ith element
-              onClick={(e) => {
-                e.preventDefault();
-                removeHeader(key);
-              }}
-            >
-              <Trash className="inline" size={16} />
-            </button>
           </li>
-        );
+        ) : undefined;
       })}
     </ul>
   );

--- a/src/components/RequestForm/PatientQueryList.js
+++ b/src/components/RequestForm/PatientQueryList.js
@@ -39,7 +39,7 @@ function PatientQueryList({
     if (queryObj.gender) {
       displayStr += `${displayStr ? "; " : ""}gender: ${queryObj.gender}`;
     }
-    return displayStr;
+    return displayStr || "No query paramaters";
   }
 
   function handleQuerySelection(queryObj, queryIdx) {

--- a/src/components/RequestForm/RequestForm.js
+++ b/src/components/RequestForm/RequestForm.js
@@ -42,8 +42,15 @@ function RequestForm({
   }
   return (
     <>
-      <div className="grid place-items-center absolute inset-0 outline-none overflow-x-hidden overflow-y-auto bg-gray-400/50">
-        <div className="lg:w-4/12 p-3 rounded-lg border-black bg-white">
+      <div
+        onClick={handleClose}
+        className="grid place-items-center absolute inset-0 outline-none overflow-x-hidden overflow-y-auto bg-gray-400/50"
+      >
+        <div
+          style={{ "border-width": "1px" }}
+          className="lg:w-4/12 p-3 rounded-lg border-black bg-white"
+          onClick={(e) => e.stopPropagation()}
+        >
           <form
             onSubmit={async (e) => {
               e.preventDefault();
@@ -53,20 +60,24 @@ function RequestForm({
               currentPatientQuery={currentPatientQuery}
               setCurrentPatientQuery={setCurrentPatientQuery}
             />
+            <hr></hr>
             <PatientIdInput
               currentPatientQuery={currentPatientQuery}
               setCurrentPatientQuery={setCurrentPatientQuery}
             />
+            <hr></hr>
             <NameInput
               currentPatientQuery={currentPatientQuery}
               setCurrentPatientQuery={setCurrentPatientQuery}
               nameType="Given"
             />
+            <hr></hr>
             <NameInput
               currentPatientQuery={currentPatientQuery}
               setCurrentPatientQuery={setCurrentPatientQuery}
               nameType="Family"
             />
+            <hr></hr>
             <GenderInput
               currentPatientQuery={currentPatientQuery}
               setCurrentPatientQuery={setCurrentPatientQuery}

--- a/src/components/RequestForm/RequestForm.js
+++ b/src/components/RequestForm/RequestForm.js
@@ -43,13 +43,13 @@ function RequestForm({
   return (
     <>
       <div
-        onClick={handleClose}
+        onMouseDown={handleClose}
         className="grid place-items-center absolute inset-0 outline-none overflow-x-hidden overflow-y-auto bg-gray-400/50"
       >
         <div
-          style={{ "border-width": "1px" }}
+          style={{ borderWidth: "1px" }}
           className="lg:w-4/12 p-3 rounded-lg border-black bg-white"
-          onClick={(e) => e.stopPropagation()}
+          onMouseDown={(e) => e.stopPropagation()}
         >
           <form
             onSubmit={async (e) => {

--- a/src/lib/fetchingUtils.js
+++ b/src/lib/fetchingUtils.js
@@ -3,14 +3,15 @@ import axios from "axios";
 /**
  * Takes an array of patient query URLS and fetches FHIR resources for each of them
  * @param {String[]} patientQueries - An array of query urls to perform GET requests on
+ * @param {Object} requestHeaders - An object containing request headers to be included in each GET request
  * @returns {Object[]} Returns an array of FHIR patient resources
  */
-async function fetchPatients(patientQueries) {
+async function fetchPatients(patientQueries, requestHeaders) {
   let patientResourceArray = [];
 
   for (const query of patientQueries) {
     await axios
-      .get(query)
+      .get(query, { headers: requestHeaders })
       .then((res) => {
         res.data.entry.forEach((entry) => {
           if (
@@ -69,12 +70,16 @@ function generateQueryUrl(serverUrl, queryObj) {
 
 /**
  * Takes a patient ID and fetches RTTD Procedure resources that patient
+ * @param {String} severUrl - The base sever URL
  * @param {String} patientId - A patient ID to fetch Procedure resources for
+ * @param {Object} requestHeaders - An object containing request headers to be included in each GET request
  * @returns {Object[]} Returns an array of FHIR Procedure resources for that Patient
  */
-async function fetchProcedures(serverUrl, patientId) {
+async function fetchProcedures(serverUrl, patientId, requestHeaders) {
   const procedureResources = await axios
-    .get(`${serverUrl}/Procedure?subject:Patient=${patientId}`)
+    .get(`${serverUrl}/Procedure?subject:Patient=${patientId}`, {
+      headers: requestHeaders,
+    })
     .then((res) => res.data)
     .catch((e) => {
       console.error(e);
@@ -85,12 +90,16 @@ async function fetchProcedures(serverUrl, patientId) {
 
 /**
  * Takes a patient ID and fetches RTTD Volumes resources that patient
+ * @param {String} severUrl - The base sever URL
  * @param {String} patientId - A patient ID to fetch Procedure resources for
+ * @param {Object} requestHeaders - An object containing request headers to be included in each GET request
  * @returns {Object[]} Returns an array of FHIR BodyStructure resources for that Patient
  */
-async function fetchVolumes(serverUrl, patientId) {
+async function fetchVolumes(serverUrl, patientId, requestHeaders) {
   const volumeResources = await axios
-    .get(`${serverUrl}/BodyStructure?patient:Patient=${patientId}`)
+    .get(`${serverUrl}/BodyStructure?patient:Patient=${patientId}`, {
+      headers: requestHeaders,
+    })
     .then((res) => res.data)
     .catch((e) => {
       console.error(e);
@@ -101,12 +110,16 @@ async function fetchVolumes(serverUrl, patientId) {
 
 /**
  * Takes a patient ID and fetches ServiceRequest resources that patient
+ * @param {String} severUrl - The base sever URL
  * @param {String} patientId - A patient ID to fetch ServiceRequest resources for
+ * @param {Object} requestHeaders - An object containing request headers to be included in each GET request
  * @returns {Object[]} Returns an array of FHIR ServiceRequest resources for that Patient
  */
-async function fetchServiceRequests(serverUrl, patientId) {
+async function fetchServiceRequests(serverUrl, patientId, requestHeaders) {
   const serviceRequests = await axios
-    .get(`${serverUrl}/ServiceRequest?subject:Patient=${patientId}`)
+    .get(`${serverUrl}/ServiceRequest?subject:Patient=${patientId}`, {
+      headers: requestHeaders,
+    })
     .then((res) => res.data)
     .catch((e) => {
       console.error(e);


### PR DESCRIPTION
Updates the web app to allow for request headers to be specified and included in all GET requests. This can be tested by adding a request header in the UI (I suggest a key of `Authentication` and any value that you'll recognize as axis will not overwrite this value), then clicking the fetch button and inspecting the request objects in the Network panel. You should see the header that you included in the panel. 

Also addresses a few UX things in the `RequestForm` that bothered me: 

- Adds a border around the modal and horizontal lines between each input field.
- The Request Form can now be closed by clicking the surrounding display area. 
- If there are no patient queries, the fetch button is disabled and text is displayed urging the user to write a request. 

