### PR TITLE
Steam 968 UI changes

### DIFF
--- a/src/components/DataView/DataView.js
+++ b/src/components/DataView/DataView.js
@@ -119,13 +119,13 @@ function DataView({ resourceMap = {}, patientIds = [] }) {
         <>
           <PatientTable className="my-4" data={patientData} />
           <TreatmentVolumeTable className="my-4" data={treatmentVolumesData} />
-          <TreatmentPhaseTable className="my-4" data={treatmentPhaseData} />
+          <PlannedCourseTable className="my-4" data={plannedCourseData} />
           <PlannedTreatmentPhaseTable
             className="my-4"
             data={plannedTreatmentPhaseData}
           />
-          <PlannedCourseTable className="my-4" data={plannedCourseData} />
           <CourseSummaryTable className="my-4" data={courseSummaryData} />
+          <TreatmentPhaseTable className="my-4" data={treatmentPhaseData} />
         </>
       )}
     </>

--- a/src/components/DataView/MultiEntryDataTable.js
+++ b/src/components/DataView/MultiEntryDataTable.js
@@ -8,11 +8,12 @@ function MultiEntryDataTable({
   title,
   columnTitle,
   className,
+  additionalHeader = "",
 }) {
   const exampleInstance = dataArray.length > 0 && dataArray[0];
   const keys =
     exampleInstance &&
-    Object.keys(exampleInstance).filter((key) => key !== "Volume Label");
+    Object.keys(exampleInstance).filter((key) => key !== additionalHeader);
   //  Each row is the key followed by all the values it follows.
   const rows = keys
     ? keys.map((k, i) => {
@@ -33,7 +34,9 @@ function MultiEntryDataTable({
               return (
                 <TableHeader
                   key={i}
-                  text={`${columnTitle} ${i + 1} (${instance["Volume Label"]})`}
+                  text={`${columnTitle} ${i + 1}${
+                    additionalHeader ? ` (${instance[additionalHeader]})` : ""
+                  }`}
                 />
               );
             })}

--- a/src/components/DataView/MultiEntryDataTable.js
+++ b/src/components/DataView/MultiEntryDataTable.js
@@ -10,7 +10,9 @@ function MultiEntryDataTable({
   className,
 }) {
   const exampleInstance = dataArray.length > 0 && dataArray[0];
-  const keys = exampleInstance && Object.keys(exampleInstance);
+  const keys =
+    exampleInstance &&
+    Object.keys(exampleInstance).filter((key) => key !== "Volume Label");
   //  Each row is the key followed by all the values it follows.
   const rows = keys
     ? keys.map((k, i) => {
@@ -28,7 +30,12 @@ function MultiEntryDataTable({
             <TableHeader isFirstCol text={title} />
             {/* Header for each element we have data for */}
             {dataArray.map((instance, i) => {
-              return <TableHeader key={i} text={`${columnTitle} ${i + 1}`} />;
+              return (
+                <TableHeader
+                  key={i}
+                  text={`${columnTitle} ${i + 1} (${instance["Volume Label"]})`}
+                />
+              );
             })}
           </tr>
         </thead>

--- a/src/components/DataView/ProfileVisualizers/CourseSummaryTable.js
+++ b/src/components/DataView/ProfileVisualizers/CourseSummaryTable.js
@@ -47,6 +47,7 @@ function CourseSummaryTable({ data = [], className }) {
           dataArray={volumesData}
           title="Dose Delivered to Volumes"
           columnTitle="Dose to Volume"
+          additionalHeader="Volume Label"
         />
         {courseSummary.metadata ? (
           <SimpleDataTable

--- a/src/components/DataView/ProfileVisualizers/CourseSummaryTable.js
+++ b/src/components/DataView/ProfileVisualizers/CourseSummaryTable.js
@@ -1,5 +1,6 @@
 import SimpleDataTable from "../SimpleDataTable";
 import MultiEntryDataTable from "../MultiEntryDataTable";
+import TwoColumnDataTable from "../TwoColumnDataTable";
 import EmptyDataTable from "../EmptyDataTable";
 import _ from "lodash";
 
@@ -23,6 +24,8 @@ function CourseSummaryTable({ data = [], className }) {
       });
     }
     const courseData = { ...courseSummary };
+    const modalityData = courseSummary["Modalities"];
+    delete courseData["Modalities"];
     delete courseData["Number of Delivered Fractions"];
     delete courseData["Total Delivered Dose [cGy]"];
     delete courseData["Volume Label"];
@@ -30,6 +33,14 @@ function CourseSummaryTable({ data = [], className }) {
       <div key={i} className={className}>
         {/* Display the base course data with a simple table */}
         <SimpleDataTable data={courseData} title={title} />
+        {/* Display Modality and Technique data with a two column table */}
+        {modalityData && modalityData.length > 0 && (
+          <TwoColumnDataTable
+            data={modalityData}
+            column1="Modality"
+            column2="Techniques"
+          />
+        )}
         {/* Display the volume data with the multi-entry table */}
         <MultiEntryDataTable
           dataArray={volumesData}

--- a/src/components/DataView/ProfileVisualizers/PlannedCourseTable.js
+++ b/src/components/DataView/ProfileVisualizers/PlannedCourseTable.js
@@ -1,5 +1,6 @@
 import SimpleDataTable from "../SimpleDataTable";
 import MultiEntryDataTable from "../MultiEntryDataTable";
+import TwoColumnDataTable from "../TwoColumnDataTable";
 import EmptyDataTable from "../EmptyDataTable";
 import _ from "lodash";
 
@@ -23,13 +24,23 @@ function PlannedCourseTable({ data = [], className }) {
       });
     }
     const plannedCourseData = { ...plannedCourse };
+    const modalityData = plannedCourse["Modalities"];
     delete plannedCourseData["Number of Planned Fractions"];
     delete plannedCourseData["Total Planned Dose [cGy]"];
     delete plannedCourseData["Volume Label"];
+    delete plannedCourseData["Modalities"];
     return (
       <div key={i} className={className}>
         {/* Display the base course data with a simple table */}
         <SimpleDataTable data={plannedCourseData} title={title} />
+        {/* Display Modality and Technique data with a two column table */}
+        {modalityData && modalityData.length > 0 && (
+          <TwoColumnDataTable
+            data={modalityData}
+            column1="Modality"
+            column2="Techniques"
+          />
+        )}
         {/* Display the volume data with the multi-entry table */}
         <MultiEntryDataTable
           dataArray={volumesData}

--- a/src/components/DataView/ProfileVisualizers/PlannedCourseTable.js
+++ b/src/components/DataView/ProfileVisualizers/PlannedCourseTable.js
@@ -48,6 +48,7 @@ function PlannedCourseTable({ data = [], className }) {
           dataArray={volumesData}
           title="Planned Dose to Volumes"
           columnTitle="Dose to Volume"
+          additionalHeader="Volume Label"
         />
         {plannedCourse.metadata ? (
           <SimpleDataTable

--- a/src/components/DataView/ProfileVisualizers/PlannedTreatmentPhaseTable.js
+++ b/src/components/DataView/ProfileVisualizers/PlannedTreatmentPhaseTable.js
@@ -49,6 +49,7 @@ function PlannedTreatmentPhaseTable({ data = [], className }) {
           dataArray={volumesData}
           title="Planned Dose to Volumes"
           columnTitle="Dose to Volume"
+          additionalHeader="Volume Label"
         />
         {plannedPhase.metadata ? (
           <SimpleDataTable

--- a/src/components/DataView/ProfileVisualizers/PlannedTreatmentPhaseTable.js
+++ b/src/components/DataView/ProfileVisualizers/PlannedTreatmentPhaseTable.js
@@ -5,10 +5,12 @@ import EmptyDataTable from "../EmptyDataTable";
 
 function PlannedTreatmentPhaseTable({ data = [], className }) {
   if (_.isEmpty(data)) {
-    return <EmptyDataTable title="Planned Phase" className={className} />;
+    return (
+      <EmptyDataTable title="Planned Treatment Phase" className={className} />
+    );
   }
   return data.map((plannedPhase, i) => {
-    const title = `Planned Phase ${i + 1}`;
+    const title = `Planned Treatment Phase ${i + 1}`;
     // Compact so we don't make space for empty entries
     const numVolumes = _.compact(
       plannedPhase["Total Planned Dose [cGy]"]

--- a/src/components/DataView/ProfileVisualizers/PlannedTreatmentPhaseTable.js
+++ b/src/components/DataView/ProfileVisualizers/PlannedTreatmentPhaseTable.js
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import SimpleDataTable from "../SimpleDataTable";
 import MultiEntryDataTable from "../MultiEntryDataTable";
+import TwoColumnDataTable from "../TwoColumnDataTable";
 import EmptyDataTable from "../EmptyDataTable";
 
 function PlannedTreatmentPhaseTable({ data = [], className }) {
@@ -25,6 +26,8 @@ function PlannedTreatmentPhaseTable({ data = [], className }) {
       });
     }
     const plannedPhaseData = { ...plannedPhase };
+    const modalityData = plannedPhase["Modalities"];
+    delete plannedPhaseData["Modalities"];
     delete plannedPhaseData["Planned Dose per Fraction [cGy]"];
     delete plannedPhaseData["Total Planned Dose [cGy]"];
     delete plannedPhaseData["Volume Label"];
@@ -32,6 +35,14 @@ function PlannedTreatmentPhaseTable({ data = [], className }) {
       <div className={className} key={i}>
         {/* Display the base phase data with a simple table */}
         <SimpleDataTable data={plannedPhaseData} title={title} />
+        {/* Display Modality and Technique data with a two column table */}
+        {modalityData && modalityData.length > 0 && (
+          <TwoColumnDataTable
+            data={modalityData}
+            column1="Modality"
+            column2="Techniques"
+          />
+        )}
         {/* Display the volume data with the multi-entry table */}
         <MultiEntryDataTable
           dataArray={volumesData}

--- a/src/components/DataView/ProfileVisualizers/TreatmentPhaseTable.js
+++ b/src/components/DataView/ProfileVisualizers/TreatmentPhaseTable.js
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import SimpleDataTable from "../SimpleDataTable";
 import MultiEntryDataTable from "../MultiEntryDataTable";
+import TwoColumnDataTable from "../TwoColumnDataTable";
 import EmptyDataTable from "../EmptyDataTable";
 
 function TreatmentPhaseTable({ data = [], className }) {
@@ -22,12 +23,22 @@ function TreatmentPhaseTable({ data = [], className }) {
       });
     }
     const treatmentPhaseData = { ...treatmentPhase };
+    const modalityData = treatmentPhase["Modalities"];
+    delete treatmentPhaseData["Modalities"];
     delete treatmentPhaseData["Total Dose Delivered [cGy]"];
     delete treatmentPhaseData["Volume Label"];
     return (
       <div className={className} key={i}>
         {/* Display the base phase data with a simple table */}
         <SimpleDataTable data={treatmentPhaseData} title={title} />
+        {/* Display Modality and Technique data with a two column table */}
+        {modalityData && modalityData.length > 0 && (
+          <TwoColumnDataTable
+            data={modalityData}
+            column1="Modality"
+            column2="Techniques"
+          />
+        )}
         {/* Display the volume data with the multi-entry table */}
         <MultiEntryDataTable
           dataArray={volumesData}

--- a/src/components/DataView/ProfileVisualizers/TreatmentPhaseTable.js
+++ b/src/components/DataView/ProfileVisualizers/TreatmentPhaseTable.js
@@ -5,10 +5,10 @@ import EmptyDataTable from "../EmptyDataTable";
 
 function TreatmentPhaseTable({ data = [], className }) {
   if (_.isEmpty(data)) {
-    return <EmptyDataTable title="Phase" className={className} />;
+    return <EmptyDataTable title="Treated Phase" className={className} />;
   }
   return data.map((treatmentPhase, i) => {
-    const title = `Phase ${i + 1}`;
+    const title = `Treated Phase ${i + 1}`;
     // Compact so we don't make space for empty entries
     const numVolumes = _.compact(
       treatmentPhase["Total Dose Delivered [cGy]"]

--- a/src/components/DataView/ProfileVisualizers/TreatmentPhaseTable.js
+++ b/src/components/DataView/ProfileVisualizers/TreatmentPhaseTable.js
@@ -45,6 +45,7 @@ function TreatmentPhaseTable({ data = [], className }) {
           dataArray={volumesData}
           title="Dose Delivered to Volumes"
           columnTitle="Dose to Volume"
+          additionalHeader="Volume Label"
         />
         {treatmentPhase.metadata ? (
           <SimpleDataTable

--- a/src/components/DataView/ProfileVisualizers/TreatmentVolumeTable.js
+++ b/src/components/DataView/ProfileVisualizers/TreatmentVolumeTable.js
@@ -16,7 +16,7 @@ function TreatmentVolumeTable({ data = [], className }) {
   data.forEach((x) => {
     const { metadata, ...volume } = x;
     volumeData.push(volume);
-    volumeMetadata.push(metadata);
+    metadata && volumeMetadata.push(metadata);
   });
   return (
     <div className={className}>
@@ -24,8 +24,9 @@ function TreatmentVolumeTable({ data = [], className }) {
         dataArray={volumeData}
         title="Radiotherapy Volumes (Targets)"
         columnTitle="Volume"
+        additionalHeader="Volume Label"
       />
-      {volumeMetadata ? (
+      {volumeMetadata && volumeMetadata.length > 0 ? (
         <MultiEntryDataTable
           dataArray={volumeMetadata}
           title="Resource Metadata"

--- a/src/components/DataView/TableData.js
+++ b/src/components/DataView/TableData.js
@@ -1,6 +1,6 @@
 import { dataDisplay } from "../../lib/dataDisplay";
 
-function TableData({ isFirstCol, data }) {
+function TableData({ isFirstCol, data, customStyles = {} }) {
   if (isFirstCol) {
     return (
       <th
@@ -9,6 +9,7 @@ function TableData({ isFirstCol, data }) {
         style={{
           wordBreak: "break-word",
           minWidth: "10rem",
+          ...customStyles,
         }}
       >
         {dataDisplay(data)}
@@ -21,6 +22,7 @@ function TableData({ isFirstCol, data }) {
         style={{
           wordBreak: "break-word",
           minWidth: "20rem",
+          ...customStyles,
         }}
       >
         {dataDisplay(data)}

--- a/src/components/DataView/TwoColumnDataTable.js
+++ b/src/components/DataView/TwoColumnDataTable.js
@@ -1,0 +1,37 @@
+import TableData from "./TableData";
+import TableHeader from "./TableHeader";
+import TableRow from "./TableRow";
+
+function TwoColumnDataTable({ data = [], column1, column2, className }) {
+  return (
+    <div
+      className={`max-w-screen-xl w-min border overflow-x-auto ${className} table-container`}
+    >
+      <table className={`table-fixed text-left `}>
+        <thead>
+          <tr className="border-b bg-slate-200">
+            <TableHeader isFirstCol text={column1} />
+            <TableHeader text={column2} />
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((value, i) => {
+            return (
+              <TableRow key={`${column1}-${i}`}>
+                <TableData
+                  customStyles={{ minWidth: "10rem" }}
+                  data={value[column1]}
+                />
+                <TableData
+                  customStyles={{ minWidth: "10rem" }}
+                  data={value[column2]}
+                />
+              </TableRow>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+export default TwoColumnDataTable;

--- a/src/lib/dataDisplay.js
+++ b/src/lib/dataDisplay.js
@@ -3,11 +3,28 @@ import { DateTime } from "luxon";
 import EmptyComponent from "../components/DataView/EmptyComponent";
 
 function dateFormat(data) {
-  return DateTime.fromISO(data).toLocaleString({
+  const dateObj = DateTime.fromISO(data);
+
+  const localeOptions = {
     month: "long",
     day: "numeric",
     year: "numeric",
-  });
+  };
+
+  /* 
+  The inclusion of T in the DateTime indicates a time is included. We don't 
+  want to include a minute and hour in our options otherwise, as a time of
+  12:00 AM will be returned when no time is present
+  */
+  if (data.includes("T")) {
+    localeOptions.hour = "2-digit";
+    localeOptions.minute = "2-digit";
+  }
+
+  // Include a time zone if we have a time, no time zone otherwise
+  return `${dateObj.toLocaleString(localeOptions)}${
+    data.includes("T") ? " " + dateObj.offsetNameShort : ""
+  }`;
 }
 
 function booleanFormat(data) {

--- a/src/lib/mappingUtils.js
+++ b/src/lib/mappingUtils.js
@@ -15,13 +15,13 @@ function getModalities(resource, resourceType) {
 
   return extensions.map((extension) => {
     return {
-      Modality: extension.extension.find(
+      Modality: extension.extension?.find(
         (extension) =>
           extension.url ===
           "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality"
-      ).valueCodeableConcept.coding[0].display,
+      )?.valueCodeableConcept?.coding[0]?.display,
       Techniques: extension.extension
-        .filter(
+        ?.filter(
           (extension) =>
             extension.url ===
             "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-technique"

--- a/src/lib/mappingUtils.js
+++ b/src/lib/mappingUtils.js
@@ -8,20 +8,30 @@ function getProcedureIntent(resource, resourceType) {
   )[0];
 }
 function getModalities(resource, resourceType) {
-  return fhirpath
-    .evaluate(
-      resource,
-      `${resourceType}.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality').valueCodeableConcept.coding.display`
-    )
-    .join("\n");
-}
-function getTechniques(resource, resourceType) {
-  return fhirpath
-    .evaluate(
-      resource,
-      `${resourceType}.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique').extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-technique').valueCodeableConcept.coding.display`
-    )
-    .join("\n");
+  const extensions = fhirpath.evaluate(
+    resource,
+    `${resourceType}.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique')`
+  );
+
+  return extensions.map((extension) => {
+    return {
+      Modality: extension.extension.find(
+        (extension) =>
+          extension.url ===
+          "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality"
+      ).valueCodeableConcept.coding[0].display,
+      Techniques: extension.extension
+        .filter(
+          (extension) =>
+            extension.url ===
+            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-technique"
+        )
+        .map((techniqueObj) => {
+          return techniqueObj.valueCodeableConcept.coding[0].display;
+        })
+        .join("\n"),
+    };
+  });
 }
 function getBodySites(resource, resourceType) {
   return fhirpath.evaluate(resource, `${resourceType}.bodySite.coding.display`);
@@ -89,7 +99,6 @@ function mapCourseSummary(procedure, includeMetadata = true) {
     output["Start Date"] = summary?.performedPeriod?.start;
     output["End Date"] = summary?.performedPeriod?.end;
     output["Modalities"] = getModalities(summary, "Procedure");
-    output["Techniques"] = getTechniques(summary, "Procedure");
     output["Number of Sessions"] = fhirpath.evaluate(
       summary,
       "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-sessions').valueUnsignedInt"
@@ -133,7 +142,6 @@ function mapTreatedPhase(procedure, includeMetadata = true) {
     output["Start Date"] = phase?.performedPeriod?.start;
     output["End Date"] = phase?.performedPeriod?.end;
     output["Modalities"] = getModalities(phase, "Procedure");
-    output["Techniques"] = getTechniques(phase, "Procedure");
     output["Number of Fractions Delivered"] = fhirpath.evaluate(
       phase,
       "Procedure.extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-fractions-delivered').valueUnsignedInt"
@@ -172,7 +180,6 @@ function mapPlannedTreatmentPhases(serviceRequests, includeMetadata = true) {
     output["Request Intent"] = plannedPhase?.intent;
     // IG states there will be at most one procedure intent
     output["Modalities"] = getModalities(plannedPhase, "ServiceRequest");
-    output["Techniques"] = getTechniques(plannedPhase, "ServiceRequest");
     output["Planned Number of Fractions"] = fhirpath.evaluate(
       plannedPhase,
       "ServiceRequest.extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-fractions-planned').valuePositiveInt"
@@ -222,8 +229,6 @@ function mapPlannedCourses(serviceRequests, includeMetadata = true) {
     );
     // One display value should suffice
     output["Modalities"] = getModalities(plannedCourse, "ServiceRequest");
-    // One display value should suffice
-    output["Techniques"] = getTechniques(plannedCourse, "ServiceRequest");
     // IG states there will be at most one value for # sessions
     output["Number of Sessions"] = fhirpath.evaluate(
       plannedCourse,


### PR DESCRIPTION
Makes a few changes requested by Michelle:
1. Times and time zones are included with date times that include that information.
2. Dose to Volume tables now include the "volume Label" in the title of each column. 
3. Modalities and Techniques have been split off into their own table. One modality can have several techniques, which will be separated by new lines. 
4. Tables have been reordered per Michelle's suggestions.