### PR TITLE
Adding option to toggle metadata + visually distinguishing metadata

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -41,6 +41,7 @@ function App() {
   ]);
   const [currentPatientQuery, setCurrentPatientQuery] = useState({});
   const [currentPatientQueryIdx, setCurrentPatientQueryIdx] = useState();
+  const [includeMetadata, setIncludeMetadata] = useState(false);
   const [patientQueries, setPatientQueries] = useState([
     {
       id: "Patient-XRTS-01-22A",
@@ -102,6 +103,10 @@ function App() {
     setShowHeaderForm(true);
   }
 
+  function toggleMetadata() {
+    setIncludeMetadata(!includeMetadata);
+  }
+
   function createHeaderObj() {
     const headerObj = {};
     requestHeaders.forEach(([key, value]) => {
@@ -142,12 +147,12 @@ function App() {
         headerObj
       );
       resourceMap.set(patient.id, [
-        mapPatient(patient),
-        mapTreatedPhase(procedures),
-        mapCourseSummary(procedures),
-        mapVolumes(volumes),
-        mapPlannedCourses(serviceRequests),
-        mapPlannedTreatmentPhases(serviceRequests),
+        mapPatient(patient, includeMetadata),
+        mapTreatedPhase(procedures, includeMetadata),
+        mapCourseSummary(procedures, includeMetadata),
+        mapVolumes(volumes, includeMetadata),
+        mapPlannedCourses(serviceRequests, includeMetadata),
+        mapPlannedTreatmentPhases(serviceRequests, includeMetadata),
       ]);
     }
     setSearchedPatientIds(patientResources.map((patient) => patient.id));
@@ -214,6 +219,10 @@ function App() {
               Please create a patient query
             </p>
           )}
+          <div key="metadata" className="space-x-1">
+            <input type="checkbox" onChange={toggleMetadata} />
+            <label>Include Metadata?</label>
+          </div>
           <button
             className="my-4 p-2 border border-gray-400 bg-slate-100 hover:bg-slate-200 disabled:bg-slate-200 cursor-pointer disabled:cursor-not-allowed transition-all shadow-lg active:shadow "
             onClick={async (e) => {

--- a/src/components/DataView/ProfileVisualizers/CourseSummaryTable.js
+++ b/src/components/DataView/ProfileVisualizers/CourseSummaryTable.js
@@ -26,6 +26,7 @@ function CourseSummaryTable({ data = [], className }) {
     delete courseData["Number of Delivered Fractions"];
     delete courseData["Total Delivered Dose [cGy]"];
     delete courseData["Volume Label"];
+    delete courseData.metadata;
     return (
       <div key={i} className={className}>
         {/* Display the base course data with a simple table */}
@@ -36,6 +37,12 @@ function CourseSummaryTable({ data = [], className }) {
           title="Dose Delivered to Volumes"
           columnTitle="Dose to Volume"
         />
+        {courseSummary.metadata ? (
+          <SimpleDataTable
+            data={courseSummary.metadata}
+            title="Resource Metadata"
+          />
+        ) : undefined}
       </div>
     );
   });

--- a/src/components/DataView/ProfileVisualizers/PatientTable.js
+++ b/src/components/DataView/ProfileVisualizers/PatientTable.js
@@ -6,12 +6,14 @@ function PatientTable({ data = {}, className }) {
   if (_.isEmpty(data)) {
     return <EmptyDataTable title="Patient Information" className={className} />;
   }
+  const { metadata, ...patientData } = data;
   return (
-    <SimpleDataTable
-      data={data}
-      className={className}
-      title="Patient Information"
-    />
+    <div className={className}>
+      <SimpleDataTable data={patientData} title="Patient Information" />
+      {metadata ? (
+        <SimpleDataTable data={metadata} title="Resource Metadata" />
+      ) : undefined}
+    </div>
   );
 }
 

--- a/src/components/DataView/ProfileVisualizers/PlannedCourseTable.js
+++ b/src/components/DataView/ProfileVisualizers/PlannedCourseTable.js
@@ -26,6 +26,7 @@ function PlannedCourseTable({ data = [], className }) {
     delete plannedCourseData["Number of Planned Fractions"];
     delete plannedCourseData["Total Planned Dose [cGy]"];
     delete plannedCourseData["Volume Label"];
+    delete plannedCourseData.metadata;
     return (
       <div key={i} className={className}>
         {/* Display the base course data with a simple table */}
@@ -36,6 +37,12 @@ function PlannedCourseTable({ data = [], className }) {
           title="Planned Dose to Volumes"
           columnTitle="Dose to Volume"
         />
+        {plannedCourse.metadata ? (
+          <SimpleDataTable
+            data={plannedCourse.metadata}
+            title="Resource Metadata"
+          />
+        ) : undefined}
       </div>
     );
   });

--- a/src/components/DataView/ProfileVisualizers/PlannedTreatmentPhaseTable.js
+++ b/src/components/DataView/ProfileVisualizers/PlannedTreatmentPhaseTable.js
@@ -26,6 +26,7 @@ function PlannedTreatmentPhaseTable({ data = [], className }) {
     delete plannedPhaseData["Planned Dose per Fraction [cGy]"];
     delete plannedPhaseData["Total Planned Dose [cGy]"];
     delete plannedPhaseData["Volume Label"];
+    delete plannedPhaseData.metadata;
     return (
       <div className={className} key={i}>
         {/* Display the base phase data with a simple table */}
@@ -36,6 +37,12 @@ function PlannedTreatmentPhaseTable({ data = [], className }) {
           title="Planned Dose to Volumes"
           columnTitle="Dose to Volume"
         />
+        {plannedPhase.metadata ? (
+          <SimpleDataTable
+            data={plannedPhase.metadata}
+            title="Resource Metadata"
+          />
+        ) : undefined}
       </div>
     );
   });

--- a/src/components/DataView/ProfileVisualizers/TreatmentPhaseTable.js
+++ b/src/components/DataView/ProfileVisualizers/TreatmentPhaseTable.js
@@ -24,6 +24,7 @@ function TreatmentPhaseTable({ data = [], className }) {
     const treatmentPhaseData = { ...treatmentPhase };
     delete treatmentPhaseData["Total Dose Delivered [cGy]"];
     delete treatmentPhaseData["Volume Label"];
+    delete treatmentPhaseData.metadata;
     return (
       <div className={className} key={i}>
         {/* Display the base phase data with a simple table */}
@@ -34,6 +35,12 @@ function TreatmentPhaseTable({ data = [], className }) {
           title="Dose Delivered to Volumes"
           columnTitle="Dose to Volume"
         />
+        {treatmentPhase.metadata ? (
+          <SimpleDataTable
+            data={treatmentPhase.metadata}
+            title="Resource Metadata"
+          />
+        ) : undefined}
       </div>
     );
   });

--- a/src/components/DataView/ProfileVisualizers/TreatmentVolumeTable.js
+++ b/src/components/DataView/ProfileVisualizers/TreatmentVolumeTable.js
@@ -11,13 +11,28 @@ function TreatmentVolumeTable({ data = [], className }) {
       />
     );
   }
+  const volumeData = [];
+  const volumeMetadata = [];
+  data.forEach((x) => {
+    const { metadata, ...volume } = x;
+    volumeData.push(volume);
+    volumeMetadata.push(metadata);
+  });
   return (
-    <MultiEntryDataTable
-      dataArray={data}
-      className={className}
-      title="Radiotherapy Volumes (Targets)"
-      columnTitle="Volume"
-    />
+    <div className={className}>
+      <MultiEntryDataTable
+        dataArray={volumeData}
+        title="Radiotherapy Volumes (Targets)"
+        columnTitle="Volume"
+      />
+      {volumeMetadata ? (
+        <MultiEntryDataTable
+          dataArray={volumeMetadata}
+          title="Resource Metadata"
+          columnTitle="Volume"
+        />
+      ) : undefined}
+    </div>
   );
 }
 

--- a/src/lib/mappingUtils.js
+++ b/src/lib/mappingUtils.js
@@ -63,7 +63,10 @@ function mapPatient(patient, includeMetadata = true) {
   output["Date of Birth"] = patient?.birthDate;
   output["Administrative Gender"] = patient?.gender;
   output["Birth Sex"] = "N/A"; //patient?.extension[0].valueCode;
-  return { ...output, ...(includeMetadata ? getMetadata(patient) : {}) };
+  return {
+    ...output,
+    ...(includeMetadata ? { metadata: getMetadata(patient) } : {}),
+  };
 }
 
 /**
@@ -109,7 +112,7 @@ function mapCourseSummary(procedure, includeMetadata = true) {
     output["Body Sites"] = getBodySites(summary, "Procedure");
     outputs.push({
       ...output,
-      ...(includeMetadata ? getMetadata(summary) : {}),
+      ...(includeMetadata ? { metadata: getMetadata(summary) } : {}),
     });
   });
   return outputs;
@@ -147,7 +150,10 @@ function mapTreatedPhase(procedure, includeMetadata = true) {
       "Procedure.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-dose-delivered-to-volume').extension.where(url = 'volume').valueReference.display"
     );
     output["Body Sites"] = getBodySites(phase, "Procedure");
-    outputs.push({ ...output, ...(includeMetadata ? getMetadata(phase) : {}) });
+    outputs.push({
+      ...output,
+      ...(includeMetadata ? { metadata: getMetadata(phase) } : {}),
+    });
   });
   return outputs;
 }
@@ -192,7 +198,7 @@ function mapPlannedTreatmentPhases(serviceRequests, includeMetadata = true) {
     output["Body Sites"] = getBodySites(plannedPhase, "ServiceRequest");
     outputs.push({
       ...output,
-      ...(includeMetadata ? getMetadata(plannedPhase) : {}),
+      ...(includeMetadata ? { metadata: getMetadata(plannedPhase) } : {}),
     });
   });
   return outputs;
@@ -248,7 +254,7 @@ function mapPlannedCourses(serviceRequests, includeMetadata = true) {
 
     outputs.push({
       ...output,
-      ...(includeMetadata ? getMetadata(plannedCourse) : {}),
+      ...(includeMetadata ? { metadata: getMetadata(plannedCourse) } : {}),
     });
   });
   return outputs;
@@ -274,7 +280,7 @@ function mapVolumes(volumes, includeMetadata = true) {
       volume?.locationQualifier?.[0]?.coding?.[0]?.display ?? undefined;
     outputs.push({
       ...output,
-      ...(includeMetadata ? getMetadata(volume) : {}),
+      ...(includeMetadata ? { metadata: getMetadata(volume) } : {}),
     });
   });
   return outputs;


### PR DESCRIPTION
This PR adds a checkbox in the sidebar to give the user the option to include the metadata fields in the data view. Additionally, the profile visualizers have been changed to display the metadata fields in a sub table to visually distinguish them.