### PR TITLE
Adding query options for Identifier and Identifier System

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -45,6 +45,8 @@ function App() {
   const [patientQueries, setPatientQueries] = useState([
     {
       id: "Patient-XRTS-01-22A",
+      identifier: "",
+      system: "",
       givenName: "",
       familyName: "",
       birthDate: "",
@@ -52,6 +54,8 @@ function App() {
     },
     {
       id: "Patient-XRTS-02-22A",
+      identifier: "",
+      system: "",
       givenName: "",
       familyName: "",
       birthDate: "",
@@ -59,6 +63,8 @@ function App() {
     },
     {
       id: "Patient-XRTS-03-22A",
+      identifier: "",
+      system: "",
       givenName: "",
       familyName: "",
       birthDate: "",
@@ -66,6 +72,8 @@ function App() {
     },
     {
       id: "Patient-XRTS-04-22A",
+      identifier: "",
+      system: "",
       givenName: "",
       familyName: "",
       birthDate: "",
@@ -73,6 +81,8 @@ function App() {
     },
     {
       id: "Patient-XRTS-05-22A",
+      identifier: "",
+      system: "",
       givenName: "",
       familyName: "",
       birthDate: "",
@@ -80,6 +90,8 @@ function App() {
     },
     {
       id: "Patient-XRTS-01",
+      identifier: "",
+      system: "",
       givenName: "",
       familyName: "",
       birthDate: "",
@@ -87,6 +99,8 @@ function App() {
     },
     {
       id: "Patient-XRTS-02",
+      identifier: "",
+      system: "",
       givenName: "",
       familyName: "",
       birthDate: "",

--- a/src/components/RequestForm/PatientIdInput.js
+++ b/src/components/RequestForm/PatientIdInput.js
@@ -3,28 +3,80 @@ function PatientIdInput({ currentPatientQuery, setCurrentPatientQuery }) {
    * Update controlled state when input element is updated
    * @param {Event} e
    */
-  function handleInputUpdate(e) {
+  function handleIdInputUpdate(e) {
     const value = e.target.value;
     setCurrentPatientQuery({ ...currentPatientQuery, id: value });
   }
+  function handleIdentifierInputUpdate(e) {
+    const value = e.target.value;
+    setCurrentPatientQuery({ ...currentPatientQuery, identifier: value });
+  }
+  function handleSystemInputUpdate(e) {
+    const value = e.target.value;
+    setCurrentPatientQuery({ ...currentPatientQuery, system: value });
+  }
 
   return (
-    <div id="patient-ids-section" className="mb-4">
-      <label className="text-lg m-1" htmlFor="patientIds">
-        Patient FHIR Resource ID
-      </label>
-      <div id="id-input-row" className="flex rounded-t-lg mb-4 justify-center">
-        <input
-          type="text"
-          id="patientIds"
-          name="patientIds"
-          placeholder="e.g. PatientMrn123"
-          className="border border-slate-500 p-2 w-10/12"
-          value={currentPatientQuery.id}
-          onChange={handleInputUpdate}
-        />
+    <>
+      <div id="patient-ids-section" className="mb-4">
+        <label className="text-lg m-1" htmlFor="patientIds">
+          Patient FHIR Resource ID
+        </label>
+        <div
+          id="id-input-row"
+          className="flex rounded-t-lg mb-4 justify-center"
+        >
+          <input
+            type="text"
+            id="patientIds"
+            name="patientIds"
+            placeholder="e.g. PatientFhirId123"
+            className="border border-slate-500 p-2 w-10/12"
+            value={currentPatientQuery.id}
+            onChange={handleIdInputUpdate}
+          />
+        </div>
       </div>
-    </div>
+      <hr></hr>
+      <div id="patient-identifier-section" className="mb-4">
+        <label className="text-lg m-1" htmlFor="patientIdentifier">
+          Patient Identifier
+        </label>
+        <div
+          id="identifier-input-row"
+          className="flex rounded-t-lg mb-4 justify-center"
+        >
+          <input
+            type="text"
+            id="patientIdentifier"
+            name="patientIdentifier"
+            placeholder="e.g. PatientMrn123"
+            className="border border-slate-500 p-2 w-10/12"
+            value={currentPatientQuery.identifier}
+            onChange={handleIdentifierInputUpdate}
+          />
+        </div>
+      </div>
+      <div id="patient-identifier-system-section" className="mb-4">
+        <label className="text-lg m-1" htmlFor="patientIdentifier">
+          Identifier System
+        </label>
+        <div
+          id="system-input-row"
+          className="flex rounded-t-lg mb-4 justify-center"
+        >
+          <input
+            type="text"
+            id="patientIdSystem"
+            name="patientIdSystem"
+            placeholder="e.g. http://examplesystem.org/"
+            className="border border-slate-500 p-2 w-10/12"
+            value={currentPatientQuery.system}
+            onChange={handleSystemInputUpdate}
+          />
+        </div>
+      </div>
+    </>
   );
 }
 

--- a/src/components/RequestForm/PatientQueryList.js
+++ b/src/components/RequestForm/PatientQueryList.js
@@ -25,6 +25,16 @@ function PatientQueryList({
     if (queryObj.id) {
       displayStr += `id: ${queryObj.id}`;
     }
+    if (queryObj.identifier) {
+      displayStr += `${displayStr ? "; " : ""}identifier: ${
+        queryObj.identifier
+      }`;
+    }
+    if (queryObj.system) {
+      displayStr += `${displayStr ? "; " : ""}identifier system: ${
+        queryObj.system
+      }`;
+    }
     if (queryObj.givenName) {
       displayStr += `${displayStr ? "; " : ""}givenName: ${queryObj.givenName}`;
     }

--- a/src/lib/fetchingUtils.js
+++ b/src/lib/fetchingUtils.js
@@ -42,6 +42,8 @@ function generateQueryUrl(serverUrl, queryObj) {
 
   if (queryParams.length === 0) return;
 
+  // We only want to add the identifier once, but two input parameters could add it (identifier & system)
+  // This flag to ensure we don't add a duplicate query-param to our string. 
   let identifierPresent = false;
   queryParams.forEach((param, idx) => {
     const seperator = idx === 0 ? "?" : "&";

--- a/src/lib/fetchingUtils.js
+++ b/src/lib/fetchingUtils.js
@@ -49,6 +49,18 @@ function generateQueryUrl(serverUrl, queryObj) {
       case "id":
         urlStr += `${seperator}_id=${queryObj[param]}`;
         break;
+      case "identifier":
+        if (queryObj.system) {
+          urlStr += `${seperator}identifier=${queryObj.system}%7C${queryObj[param]}`;
+        } else {
+          urlStr += `${seperator}identifier=${queryObj[param]}`;
+        }
+        break;
+      case "system":
+        if (!queryObj.identifier) {
+          urlStr += `${seperator}identifier=${queryObj[param]}%7C`;
+        }
+        break;
       case "givenName":
         urlStr += `${seperator}given:exact=${queryObj[param]}`;
         break;

--- a/src/lib/fetchingUtils.js
+++ b/src/lib/fetchingUtils.js
@@ -42,6 +42,7 @@ function generateQueryUrl(serverUrl, queryObj) {
 
   if (queryParams.length === 0) return;
 
+  let identifierPresent = false;
   queryParams.forEach((param, idx) => {
     const seperator = idx === 0 ? "?" : "&";
 
@@ -50,15 +51,23 @@ function generateQueryUrl(serverUrl, queryObj) {
         urlStr += `${seperator}_id=${queryObj[param]}`;
         break;
       case "identifier":
-        if (queryObj.system) {
-          urlStr += `${seperator}identifier=${queryObj.system}%7C${queryObj[param]}`;
-        } else {
-          urlStr += `${seperator}identifier=${queryObj[param]}`;
+        if (!identifierPresent) {
+          if (queryObj.system) {
+            urlStr += `${seperator}identifier=${queryObj.system}%7C${queryObj[param]}`;
+          } else {
+            urlStr += `${seperator}identifier=${queryObj[param]}`;
+          }
+          identifierPresent = true;
         }
         break;
       case "system":
-        if (!queryObj.identifier) {
-          urlStr += `${seperator}identifier=${queryObj[param]}%7C`;
+        if (!identifierPresent) {
+          if (!queryObj.identifier) {
+            urlStr += `${seperator}identifier=${queryObj[param]}%7C`;
+          } else {
+            urlStr += `${seperator}identifier=${queryObj[param]}%7C${queryObj.identifier}`;
+          }
+          identifierPresent = true;
         }
         break;
       case "givenName":


### PR DESCRIPTION
This PR adds 2 new fields to the patient query options: Patient Identifier and Identifier System. These allow for users to query for patients based on identifiers of any system they want. Patient Identifier can be used without Identifier System (should return any patient with that identifier value) and Identifier System can be used without Patient Identifier (should return all patients with identifiers from that system). Additionally, Patient FHIR Resource ID should still work as usual and could be used with either of the new options.

To test:
- Make sure the app works as expected when the new fields are blank
- Test the new fields in various combinations (`http://hospital.smarthealthit.org` is the identifier system for most of the XRTS patients we use by default) and make sure they all work as expected
- Make sure my labeling of these new fields make sense. I want to avoid any confusion over what these fields do so if you have more specific or better names, let me know