### PR TITLE
Handle Multiple Names and Additional Name-data

### DIFF
--- a/src/components/DataView/DataView.js
+++ b/src/components/DataView/DataView.js
@@ -117,15 +117,15 @@ function DataView({ resourceMap = {}, patientIds = [] }) {
       {!hasPatientData && <p>No Patient Data found for {selectedPatientId}</p>}
       {hasPatientData && (
         <>
-          <PatientTable className="my-4" data={patientData} />
-          <TreatmentVolumeTable className="my-4" data={treatmentVolumesData} />
-          <PlannedCourseTable className="my-4" data={plannedCourseData} />
+          <PatientTable className="my-6" data={patientData} />
+          <TreatmentVolumeTable className="my-6" data={treatmentVolumesData} />
+          <PlannedCourseTable className="my-6" data={plannedCourseData} />
           <PlannedTreatmentPhaseTable
-            className="my-4"
+            className="my-6"
             data={plannedTreatmentPhaseData}
           />
-          <CourseSummaryTable className="my-4" data={courseSummaryData} />
-          <TreatmentPhaseTable className="my-4" data={treatmentPhaseData} />
+          <CourseSummaryTable className="my-6" data={courseSummaryData} />
+          <TreatmentPhaseTable className="my-6" data={treatmentPhaseData} />
         </>
       )}
     </>


### PR DESCRIPTION
Addresses [STEAM-1066](https://jira.mitre.org/browse/STEAM-1066) – Display all names stored on a patient.

Realizing that the HumanName datatype has much more information than we currently display, instead of having 5 rows of data distinct from eachother with unique columns for each name-instance I've replaced the several name-data related rows with a single row, "Name". This row displays a human readable string joining all name data, including prefix, suffix, family-name, given-name and use information. Specifically, use is included if it's anything other than `usual`.

Unrelated to this task, I've removed the only instances of `require` syntax from this project and changes the margins between data-tables from `my-4` to `my-6`.