### PR TITLE
Fixing bug when uploading same settings config twice in a row

### DIFF
--- a/src/components/RequestConfiguration/RequestConfigurationPanel.js
+++ b/src/components/RequestConfiguration/RequestConfigurationPanel.js
@@ -313,7 +313,10 @@ export default function RequestConfigurationPanel({
               type="file"
               className="hidden"
               accept=".json"
-              onChange={(event) => loadFile(event.target.files[0])}
+              onChange={(event) => {
+                loadFile(event.target.files[0]);
+                event.target.value = null;
+              }}
             />
             <BasicButton
               className="my-0 flex items-center"


### PR DESCRIPTION
Since uploading the config was triggered on a change event, uploading the same file twice in a row didn't trigger the change event. Adding this one line to reset the event value to null gets around this issue.